### PR TITLE
Fix type error in error handling

### DIFF
--- a/backend/src/shared/domain/models/image.ts
+++ b/backend/src/shared/domain/models/image.ts
@@ -1,0 +1,38 @@
+import { AggregateRoot } from '../AggregateRoot.js';
+import { UniqueEntityID } from '../UniqueEntityID.js';
+import { Result } from '../../core/result.js';
+import { DomainError } from '../../core/domain-error.js';
+
+export interface IImageProps {
+  imageId: string;
+  storageType: 'local' | 'googleDrive';
+  fileId: string;
+}
+
+export class Image extends AggregateRoot<IImageProps> {
+  get id(): UniqueEntityID {
+    return this._id;
+  }
+
+  get imageId(): string {
+    return this.props.imageId;
+  }
+
+  get storageType(): 'local' | 'googleDrive' {
+    return this.props.storageType;
+  }
+
+  get fileId(): string {
+    return this.props.fileId;
+  }
+
+  public static create(props: IImageProps, id?: UniqueEntityID): Result<Image, DomainError<Image>> {
+    const image = new Image(props, id);
+
+    return Result.ok<Image, DomainError<Image>>(image);
+  }
+
+  private constructor(props: IImageProps, id?: UniqueEntityID) {
+    super(props, id);
+  }
+}


### PR DESCRIPTION
Explicitly specify the error type in `Result.ok` to resolve a TypeScript type assignment error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6236e8fb-978e-483e-a24e-7b17a8e96d5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6236e8fb-978e-483e-a24e-7b17a8e96d5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

