### PR TITLE
Move block to private file

### DIFF
--- a/backend/src/modules/files/usecases/upload-image/upload-image.usecase.ts
+++ b/backend/src/modules/files/usecases/upload-image/upload-image.usecase.ts
@@ -23,8 +23,35 @@ export class UploadImageUsecase implements UseCase<UploadImageRequest, Promise<U
   public async execute(req: UploadImageRequest, user: User): Promise<UploadImageResult> {
     const file: Express.Multer.File = req.file;
     const userId: string = user.id.toString();
+
+    const processResult = await this.processAndValidateFile(file, userId);
+    if (processResult.isErr()) {
+      return processResult;
+    }
+
+    const { pathToFile, fileType } = processResult.getValue();
+
+    try {
+      const fileId: string = await this.googleDriveService.uploadFile(user, pathToFile);
+
+      return Result.ok<UploadImageResponse, never>({
+        fileId,
+        extension: fileType,
+      });
+    } catch (error) {
+      // TODO: handele error properly (as service error)
+      // TICKET: https://brainas.atlassian.net/browse/BA-218
+      console.error('Error uploading file to Google Drive:', error);
+      return new UploadImageErrors.UploadToGoogleDriveFailed();
+    }
+  }
+
+  private async processAndValidateFile(
+    file: Express.Multer.File,
+    userId: string
+  ): Promise<Result<{ pathToFile: string; fileType: string }, UploadImageError>> {
     const tempPath = file.path;
-    const originalname = req.file.originalname;
+    const originalname = file.originalname;
     const userUploadDir = `${config.paths.uploadTempDir}/${userId}`;
     const pathToFile = `${userUploadDir}/${originalname}`;
 
@@ -32,7 +59,7 @@ export class UploadImageUsecase implements UseCase<UploadImageRequest, Promise<U
       fs.mkdirSync(userUploadDir, { recursive: true });
     }
 
-    const fileType = path.extname(req.file.originalname).toLowerCase().replace('.', '');
+    const fileType = path.extname(originalname).toLowerCase().replace('.', '');
     if (!this.allowedTypes.includes(fileType)) {
       return await new Promise<Result<never, UploadImageError>>((resolve, reject) => {
         fs.unlink(tempPath, err => {
@@ -49,18 +76,6 @@ export class UploadImageUsecase implements UseCase<UploadImageRequest, Promise<U
       });
     });
 
-    try {
-      const fileId: string = await this.googleDriveService.uploadFile(user, pathToFile);
-
-      return Result.ok<UploadImageResponse, never>({
-        fileId,
-        extension: fileType,
-      });
-    } catch (error) {
-      // TODO: handele error properly (as service error)
-      // TICKET: https://brainas.atlassian.net/browse/BA-218
-      console.error('Error uploading file to Google Drive:', error);
-      return new UploadImageErrors.UploadToGoogleDriveFailed();
-    }
+    return Result.ok({ pathToFile, fileType });
   }
 }


### PR DESCRIPTION
Extract file processing and validation logic into a private method to improve code organization and testability.

This refactoring separates the concerns of file handling (validation, directory creation, moving) from the core upload logic, making the `execute` method cleaner and the file processing logic more testable in isolation.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d2df1fc-5f8c-4363-b42f-b40cf6714ce4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d2df1fc-5f8c-4363-b42f-b40cf6714ce4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

