### PR TITLE
Fix missing EImageRepoServiceError type

### DIFF
--- a/backend/src/modules/files/usecases/get-image/get-image.errors.ts
+++ b/backend/src/modules/files/usecases/get-image/get-image.errors.ts
@@ -1,0 +1,26 @@
+import { Result } from '../../../../shared/core/result.js';
+import { UseCaseError } from '../../../../shared/core/use-case-error.js';
+import { EHttpStatus } from '../../../../shared/infra/http/models/base-controller.js';
+
+export class GetImageError extends UseCaseError<GetImageErrorCodes> {}
+
+enum GetImageErrorCode {
+  ImageNotFound = 'GET_IMAGE_ERROR_CODE__IMAGE_NOT_FOUND',
+}
+
+type GetImageErrorCodes = GetImageErrorCode;
+
+export namespace GetImageErrors {
+  export class ImageNotFoundError extends Result<never, GetImageError> {
+    constructor(imageId: string) {
+      super(
+        false,
+        new GetImageError(
+          GetImageErrorCode.ImageNotFound,
+          `Image with id "${imageId}" not found`,
+          EHttpStatus.NotFound,
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
Create `get-image.errors.ts` to define errors for the GetImage use case, resolving a 'Cannot find name' error.

The `EImageRepoServiceError` enum was referenced but did not exist, leading to a compilation error. This PR defines a local error structure for `GetImage` to ensure it is self-contained and independent of the missing service file.

---
<a href="https://cursor.com/background-agent?bcId=bc-91ccfece-fdb9-49b6-b9bc-4b4853cb0c93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-91ccfece-fdb9-49b6-b9bc-4b4853cb0c93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

