### PR TITLE
Handle 404 error and retry client id

### DIFF
--- a/frontend/src/app/shared/state/sync.state.ts
+++ b/frontend/src/app/shared/state/sync.state.ts
@@ -106,7 +106,18 @@ export class SyncState {
           ctx.dispatch(new SyncServiceAPIAction.ServerChangesLoaded(changes));
         },
         error: err => {
-          ctx.dispatch(SyncServiceAPIAction.ServerChangesLoadingFailed);
+          if (err instanceof HttpErrorResponse && err.status === 404) {
+            this.getClientIdAPICall(ctx).subscribe({
+              next: () => {
+                ctx.dispatch(SyncServiceAPIAction.ServerChangesLoadingFailed);
+              },
+              error: () => {
+                ctx.dispatch(SyncServiceAPIAction.ServerChangesLoadingFailed);
+              }
+            });
+          } else {
+            ctx.dispatch(SyncServiceAPIAction.ServerChangesLoadingFailed);
+          }
           return err;
         },
       }),

--- a/frontend/src/app/shared/state/sync.state.ts
+++ b/frontend/src/app/shared/state/sync.state.ts
@@ -107,17 +107,9 @@ export class SyncState {
         },
         error: err => {
           if (err instanceof HttpErrorResponse && err.status === 404) {
-            this.getClientIdAPICall(ctx).subscribe({
-              next: () => {
-                ctx.dispatch(SyncServiceAPIAction.ServerChangesLoadingFailed);
-              },
-              error: () => {
-                ctx.dispatch(SyncServiceAPIAction.ServerChangesLoadingFailed);
-              }
-            });
-          } else {
-            ctx.dispatch(SyncServiceAPIAction.ServerChangesLoadingFailed);
+            this.getClientIdAPICall(ctx).subscribe();
           }
+          ctx.dispatch(SyncServiceAPIAction.ServerChangesLoadingFailed);
           return err;
         },
       }),


### PR DESCRIPTION
Modify `fetchServerChanges` to call `getClientIdAPICall()` on a 404 error before dispatching `ServerChangesLoadingFailed`.

---
<a href="https://cursor.com/background-agent?bcId=bc-51502e20-7a9e-4512-ac99-d4b1ec927a0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51502e20-7a9e-4512-ac99-d4b1ec927a0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

