### PR TITLE
Open readme.md presentation in new window

### DIFF
--- a/readme-viewer.html
+++ b/readme-viewer.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Brain Assistant - README Presentation</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        
+        .container {
+            background-color: white;
+            padding: 40px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        
+        h1, h2, h3, h4 {
+            color: #2c3e50;
+        }
+        
+        h1 {
+            border-bottom: 3px solid #3498db;
+            padding-bottom: 10px;
+        }
+        
+        h2 {
+            margin-top: 30px;
+            color: #3498db;
+        }
+        
+        a {
+            color: #3498db;
+            text-decoration: none;
+        }
+        
+        a:hover {
+            text-decoration: underline;
+        }
+        
+        code {
+            background-color: #f4f4f4;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: 'Consolas', 'Monaco', monospace;
+        }
+        
+        ul {
+            line-height: 1.8;
+        }
+        
+        li {
+            margin-bottom: 8px;
+        }
+        
+        img {
+            max-width: 100%;
+            height: auto;
+        }
+        
+        p {
+            text-align: center;
+        }
+        
+        p img {
+            display: inline-block;
+            vertical-align: middle;
+        }
+        
+        em {
+            color: #666;
+        }
+        
+        strong {
+            color: #2c3e50;
+        }
+        
+        /* Center alignment for header content */
+        p:has(img[alt="Brain Assistant Logo"]) {
+            text-align: center;
+            margin: 20px 0;
+        }
+        
+        /* Style for the description paragraph */
+        h4 em {
+            display: block;
+            background-color: #e8f4f8;
+            padding: 20px;
+            border-radius: 8px;
+            border-left: 4px solid #3498db;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div id="content"></div>
+    </div>
+    
+    <script>
+        // Fetch and render the README.md
+        fetch('README.md')
+            .then(response => response.text())
+            .then(markdown => {
+                // Fix image paths to use proper GitHub raw content URLs
+                const fixedMarkdown = markdown.replace(
+                    /src="\.\/\.github\//g, 
+                    'src="https://raw.githubusercontent.com/kirillushakov/public-ba-codebase/main/.github/'
+                );
+                
+                document.getElementById('content').innerHTML = marked.parse(fixedMarkdown);
+            })
+            .catch(error => {
+                document.getElementById('content').innerHTML = '<h1>Error loading README.md</h1><p>' + error + '</p>';
+            });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add `readme-viewer.html` to render `README.md` as a styled presentation.

The HTML file uses `marked.js` for markdown conversion and includes custom CSS for a clean, modern design, including centered content and corrected image paths for GitHub raw content. This directly addresses the user's request for a "second window with result of reamme.md presentation".

---
<a href="https://cursor.com/background-agent?bcId=bc-cd65d7c6-66e6-4e87-b527-a52ca2c7f300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd65d7c6-66e6-4e87-b527-a52ca2c7f300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

