### PR TITLE
Add Cursor rules for monorepo architecture and AI workflow.

### DIFF
--- a/.cursor/rules/angular.mdc
+++ b/.cursor/rules/angular.mdc
@@ -1,0 +1,48 @@
+---
+description: Angular 19 frontend conventions - components, NGXS state, HTTP, forms
+globs: frontend/**/*.ts,frontend/**/*.html
+alwaysApply: false
+---
+
+# Angular conventions
+
+The app is fully standalone and bootstrapped via `bootstrapApplication` — there are no NgModules. New components declare their own `imports` array; providers belong in `main.ts` or a route's `providers`.
+
+Prefer `inject()` in new code, as the newest features do. Do not convert existing constructor injection while working on something else.
+
+## State: NGXS
+
+Application state lives in NGXS, not in components or ad-hoc services:
+
+- slices are `*.state.ts` with `@State`, `@Selector`, `@Action`
+- actions live in `*.actions.ts` inside a namespace:
+  `export namespace TaskAction { export class Create { static readonly type = '[Task] Create'; } }`
+- global slices go in `shared/state/`; screen and feature slices sit next to the screen and are registered per route with `provideStates([...])`
+
+Components dispatch actions and read state through `selectSignal`, `createSelectMap` or `store.select` — use whichever the surrounding component already uses.
+
+Angular `signal()` is for local UI state of a single component. Do not move NGXS state into signals.
+
+## HTTP
+
+Components must never inject `HttpClient`. API calls live in `shared/services/api/`, `shared/services/integrations/`, or a feature's own `api/` folder as `*.service.ts`, and map responses to models via `shared/mappers/*`.
+
+Request and response types come from `@brainassistant/contracts` for the sync and file APIs.
+
+## Subscriptions
+
+Prefer the `async` pipe or NGXS signals. When subscribing manually, always tear down with `takeUntilDestroyed()`. Do not add a bare `.subscribe()` without cleanup, even though some older components still have them.
+
+## Templates
+
+- Use `@if` / `@for` / `@switch` in new and edited templates; leave untouched `*ngIf` blocks alone.
+- Keep logic out of templates: no non-trivial method calls in bindings, computation belongs in TypeScript.
+- Touch the DOM through Angular APIs, not directly.
+
+## Forms
+
+Reactive forms only, no `ngModel`. Type them with the existing helper: `FormGroup<FormControlsOf<T>>` from `shared/forms/types/form-controls-of.ts`. Do not add new `UntypedFormGroup` or `UntypedFormControl`.
+
+## Styles
+
+Component styles are SCSS and use the shared partials rather than raw values: breakpoints via `@use 'src/scss/breakpoints' as bp;` with `@include bp.up(md)`, plus the `_colors`, `_spacing`, `_typography` and `_button` partials.

--- a/.cursor/rules/backend-architecture.mdc
+++ b/.cursor/rules/backend-architecture.mdc
@@ -1,0 +1,55 @@
+---
+description: Backend use-case architecture, Result-based errors, Express + TypeScript ESM
+globs: backend/src/**/*.ts
+alwaysApply: false
+---
+
+# Backend architecture
+
+## ESM imports
+
+`backend` is `"type": "module"`. Every relative import needs the `.js` extension even though the source is TypeScript:
+
+```ts
+// BAD - breaks at runtime
+import { CreateTask } from './create-task.usecase';
+
+// GOOD
+import { CreateTask } from './create-task.usecase.js';
+```
+
+## Use-case folders
+
+Business flows live in `backend/src/modules/<module>/usecases/<use-case>/` and consist of:
+
+- `<name>.controller.ts` — extends `BaseController`, implements `executeImpl`
+- `<name>.usecase.ts` — implements `UseCase<Params, Promise<Result>>`, contains no Express types
+- `<name>.errors.ts` — namespaced `UseCaseError` subclasses carrying `httpCode`
+- `<name>.mapper.ts` / `<name>.dto.ts` — only when mapping is non-trivial
+- `index.ts` — composition root: instantiates repos, services, use-case and controller, exports the controller singleton
+
+Add new flows as a use-case folder matching its neighbours. Do not introduce new layers: no application-level `*.service.ts` wrapper, no `*.validation.ts`, no DI container. Match the local naming (a few folders use `_index.ts`).
+
+Routers only wire HTTP to a controller and hold no logic:
+
+```ts
+syncRouter.post('/task', (req, res) => createTaskController.execute(req, res));
+```
+
+## Errors are values, not exceptions
+
+Use-cases and repos return `Result` (`shared/core/result.ts`) and fail with a typed error from `*.errors.ts` or `serviceFail()`. There is no centralized Express error middleware — never write code that assumes one exists.
+
+Controllers branch on `result.isSuccess` and respond via `BaseController.jsonResponse(res, error.httpCode, { name, message })`, keeping the `try/catch` in `executeImpl` like neighbouring controllers.
+
+## Data access and input
+
+- Use-cases call `shared/repo/*`, never Mongoose models directly.
+- Validate external input in domain models and value objects with `Guard` + `Result` (see `shared/domain/models/task.ts`). Do not add joi, zod or express-validator.
+- Read `req.user` in the controller and pass plain values into the use-case; use-cases must not touch Express objects.
+
+## Types and secrets
+
+`backend/tsconfig.json` has no `strict` or `strictNullChecks`, so the compiler will not catch loose types. Type parameters and return values explicitly and avoid `any`.
+
+Never hard-code URLs, credentials or keys, and never log passwords, tokens or whole request bodies.

--- a/.cursor/rules/contracts.mdc
+++ b/.cursor/rules/contracts.mdc
@@ -1,0 +1,40 @@
+---
+description: Shared API contracts package @brainassistant/contracts
+globs: contracts/**/*.ts
+alwaysApply: false
+---
+
+# Shared contracts
+
+This package is the single source of truth for the HTTP boundary between `frontend` and `backend`. Both apps consume it as `file:../contracts`.
+
+## Layout
+
+- `src/dto/<name>.dto.ts` — request and response payload shapes
+- `src/enums/<name>.enum.ts` — enums that travel over the wire
+- `src/contracts/<name>.contract.ts` — per-endpoint namespaces, e.g. `SendChangeContract.Request<TaskDTO>` and `.Response`
+- every folder has an `index.ts` barrel, and `src/index.ts` re-exports the public surface
+
+Anything new must be exported from `src/index.ts` or the apps cannot see it. DTOs are re-exported with `export type`, enums with a value `export`.
+
+## Types only
+
+Keep this package free of runtime logic: no validation, no mappers, no HTTP calls, no dependencies. Mapping belongs in `backend/src/shared/mappers/` and `frontend/src/app/shared/mappers/`.
+
+## Build step
+
+The apps consume compiled output from `dist/`, so a source change is invisible until it is rebuilt:
+
+```
+cd contracts; npm run build
+```
+
+Say this explicitly whenever a change spans contracts and an app.
+
+## Compatibility
+
+The frontend is an offline PWA with a sync protocol: clients keep running cached builds long after a deploy, and their stored data follows the old shape.
+
+- Prefer additive changes and make new fields optional.
+- Do not rename or repurpose an existing field, and do not change the meaning of an existing enum value — add a new one.
+- If a breaking change is unavoidable, state it explicitly and describe how old clients and already-persisted data are handled.

--- a/.cursor/rules/mongodb.mdc
+++ b/.cursor/rules/mongodb.mdc
@@ -1,0 +1,40 @@
+---
+description: MongoDB data access - repos, models, mappers, query safety, indexes
+globs: backend/src/shared/repo/**/*.ts,backend/src/shared/infra/database/**/*.ts,backend/src/shared/mappers/**/*.ts
+alwaysApply: false
+---
+
+# MongoDB and data access
+
+## Structure
+
+- Schemas live in `shared/infra/database/mongodb/<entity>.model.ts` and are registered in `IDbModels` and `models` in that folder's `index.ts`.
+- Repos in `shared/repo/` receive `IDbModels` through the constructor and read models from it (`this.models.TaskModel`). Do not import a model module directly inside a repo.
+- Documents are converted at the boundary by `shared/mappers/<entity>.mapper.ts` (`toDomain`, `toPersistence`, `toDTO`). A raw Mongoose document must never escape a repo into a use-case.
+- Repos return `Result` with a `ServiceError` built by `serviceFail()`. Do not `throw new Error` for expected outcomes such as "not found".
+
+## Query safety
+
+- Every query returning a collection needs an explicit bound: a `userId` filter, a time window, or `.limit()` / pagination. The sync queries scoped by `userId` + `modifiedAt` are the pattern to follow.
+- Never load documents in order to filter, sort, count or group them in JavaScript when MongoDB can do it in the query.
+- Use `.lean()` for read-only queries whose result goes straight into a mapper.
+- Project only the fields you need when reading documents that may carry large payloads.
+- No N+1: never query inside a loop over documents — use `$in` or a single aggregation.
+- Modify many documents with `updateMany` or `bulkWrite`, and prefer atomic operators (`$set`, `$inc`, `findOneAndUpdate`) over read-modify-write sequences.
+
+## Indexes
+
+The existing schemas define no indexes at all. When adding a query that filters or sorts on a field that will grow — anything keyed by `userId`, `modifiedAt` or `occurredAt` — state whether an index is needed and add it to the schema deliberately. Do not add indexes speculatively; they cost write throughput and storage.
+
+## Identifiers
+
+Id types are not uniform here, so be explicit about which entity you are querying:
+
+- `Task` and `Client` store a **string** `_id` (an ObjectId hex string produced by `UniqueEntityID`).
+- `User` uses a real `ObjectId`; `user.repo.ts` converts `string` to `ObjectId` before querying.
+
+Reject malformed ids explicitly instead of passing them into a query.
+
+## Schema changes
+
+Documents already exist in production and offline clients sync against them. Do not change or drop a field without describing the migration and what happens to old documents and old clients.

--- a/.cursor/rules/ngxs.mdc
+++ b/.cursor/rules/ngxs.mdc
@@ -1,0 +1,46 @@
+---
+description: NGXS state slices, actions, selectors and persistence
+globs: frontend/src/app/**/*.state.ts,frontend/src/app/**/*.actions.ts,frontend/src/app/**/*.action.ts
+alwaysApply: false
+---
+
+# NGXS conventions
+
+## Slice shape
+
+- The state model interface is `I<Name>StateModel`; related enums are `E<Name>`.
+- The class carries `@State<I<Name>StateModel>({ name, defaults })` and `@Injectable()`.
+- Selectors are `static` methods with `@Selector()` and an explicit return type.
+- Handlers take `ctx: StateContext<I<Name>StateModel>` and update through `ctx.patchState(...)` or `ctx.setState(patch({ ... }))` from `@ngxs/store/operators`. Never mutate state in place.
+- API calls inside a slice go through an injected service from `shared/services/**`, never `HttpClient` directly.
+
+## Actions
+
+Actions live in `*.actions.ts` (a few older files use `*.action.ts` — follow the neighbouring file) inside a namespace, with a `[Scope] Human readable` type string:
+
+```ts
+export namespace UserAction {
+  export class UserLoggedInWithPassword {
+    static readonly type = '[User] User Logged In With Password';
+
+    constructor(public userData: User) {}
+  }
+}
+```
+
+Slices communicate by dispatching actions, not by injecting one another. A global slice may handle a screen's action — `UserState` handles `MbLoginScreenAction.LoginUser` — which is preferred over reaching into another slice's state.
+
+Several `@Action(...)` decorators may be stacked on one handler when actions share behaviour.
+
+## Registration
+
+- Global slices live in `shared/state/` and are registered in `main.ts` with `provideStates([...])`.
+- Screen and feature slices are co-located with their screen or feature and registered on the route: `providers: [provideStates([MbTaskScreenState, VoiceInputState])]`.
+
+## Persistence
+
+`main.ts` configures `withNgxsStoragePlugin({ keys: '*' })`, so **every** slice is persisted on the device and the app is offline-first. Therefore:
+
+- Keep state serializable: no `Blob`, `File`, DOM nodes, RxJS subjects, functions or class instances with behaviour.
+- Never put passwords or access tokens into state.
+- Adding, renaming or removing a field changes the shape of state already stored on users' devices. Write defaults and selectors that tolerate previously persisted data instead of assuming the new shape.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,0 +1,43 @@
+---
+description: Project map, monorepo workflow, and how to change this codebase
+alwaysApply: true
+---
+
+# Brain Assistant project rules
+
+## Repo map
+
+- `frontend/` — Angular 19 PWA, standalone components, NGXS state.
+- `backend/` — Express + Mongoose API, ESM, use-case architecture.
+- `contracts/` — `@brainassistant/contracts`, shared API types linked into both apps as `file:../contracts`.
+- `db/`, `nginx/`, `scripts/`, `docker-compose.yml` — infrastructure.
+
+`frontend`, `backend` and `contracts` are separate npm packages. Run `npm`/`ng` commands from inside the relevant folder, not from the repo root.
+
+## Shell
+
+The dev environment is Windows PowerShell. Do not chain commands with `&&` and do not use bash-only syntax; use `;` or separate commands.
+
+## Shared contracts
+
+- API request/response types belong in `contracts/`, not duplicated per app.
+- After editing `contracts/`, it must be rebuilt before either app sees the change: `cd contracts; npm run build`.
+- `frontend/src/app/shared/dto/` still holds legacy duplicated auth DTOs. Do not add new DTOs there — extend `contracts/` instead.
+- The frontend is an offline-capable PWA with a sync protocol, so users keep running cached builds for a long time. Treat contracts as a public API: prefer additive, backward-compatible changes, and state explicitly when a change is breaking.
+
+## Verify, do not invent
+
+Never invent API endpoints, database fields, env/config variable names, contract types, or existing behaviour. Read the relevant file first and reuse what is there.
+
+Before adding a service, helper, mapper, model or component, search for an existing one. Both apps already have `shared/` layers for each of these.
+
+## Scope of changes
+
+- Keep the change scoped to what was asked: no drive-by renames, unrelated refactors, or reformatting of files you did not need to touch.
+- Prefer modifying existing code over adding a parallel implementation beside it.
+- Do not add dependencies without a clear reason; both apps already carry a large dependency set.
+- Formatting and code style are handled by ESLint, Prettier, Stylelint and husky/lint-staged. Do not hand-format code.
+
+## Before finishing
+
+Check that the app you touched still compiles, that imports resolve, and whether existing tests in `backend/test/` or `frontend/e2e/` cover the changed behaviour.

--- a/.cursor/rules/testing-backend.mdc
+++ b/.cursor/rules/testing-backend.mdc
@@ -1,0 +1,48 @@
+---
+description: Backend integration tests - Jest, supertest, in-memory MongoDB
+globs: backend/test/**/*.ts
+alwaysApply: false
+---
+
+# Backend tests
+
+Backend testing is integration-only: a real Express app wired to the real controller, use-case, repo and Mongoose models, running against an in-memory MongoDB. Do not add unit tests that mock the layers away.
+
+## Layout and naming
+
+- `test/integration/<module>/` mirrors `src/modules/<module>/usecases/`
+- specs are `<use-case>.int.spec.ts`, described as `Integration: CreateTask (Controller -> UseCase -> Repo -> MongoDB)`
+- each folder has its own `test-app.ts` exporting a `buildTestApp()` builder
+- binary fixtures go in `test/integration/_fixtures/`, env vars in `test/setup-env.ts`
+
+Imports carry the `.js` extension like the rest of the backend (`../_setup/mongo-memory.js`).
+
+## Test app builder
+
+`buildTestApp()` instantiates the real repo, use-case and controller, mounts the controller on a route, and installs a fake auth middleware setting `(req as any).user = { _id: 'test-user-1' }`.
+
+Mock only external systems — Slack, Google Drive, OpenAI, email — as `jest.fn()` doubles. Repos, mappers, domain models and the database stay real.
+
+## Lifecycle
+
+```ts
+beforeAll(async () => {
+  await startInMemoryMongo();
+  app = buildTestApp().app;
+}, 30_000);
+
+afterAll(async () => {
+  await stopInMemoryMongo();
+});
+
+beforeEach(async () => {
+  await clearDatabase();
+  jest.clearAllMocks();
+});
+```
+
+## Assertions
+
+Assert observable outcomes rather than internals: the HTTP status, the response body typed against the DTO from `@brainassistant/contracts`, and the document read back through the model. Cover the happy path, the validation failure (status plus `name` and `message` in the body) and external-service failure.
+
+Specs must be deterministic: no real network, no assertions that depend on the current time or random values, no reliance on execution order. Do not leave `console.log` debugging in a spec.

--- a/.cursor/rules/testing-e2e.mdc
+++ b/.cursor/rules/testing-e2e.mdc
@@ -1,0 +1,32 @@
+---
+description: Frontend E2E tests with Playwright
+globs: frontend/e2e/**/*.ts
+alwaysApply: false
+---
+
+# Frontend E2E tests
+
+Playwright specs in `frontend/e2e/*.spec.ts` drive the real UI against a mocked backend, running on the `e2e` build configuration (`npm run start:e2e`, `npm run e2e`).
+
+## Selectors
+
+Target elements with `[data-test="..."]` — this project uses `data-test`, not `data-testid`:
+
+```ts
+await page.click('[data-test="new-task-btn"]');
+```
+
+If an element has no hook, add a `data-test` attribute to the template instead of selecting by CSS class or DOM position. Text and role selectors are fine for user-visible copy, e.g. `page.getByText('Sign in with Google')`.
+
+## Mocks and stubs
+
+- HTTP is mocked centrally in `e2e/utils/api-mocks.util.ts`. Call `await setupApiMocks(page)` at the start of a spec and extend that util rather than scattering `page.route` calls across specs.
+- Auth and device APIs are swapped at build time through `fileReplacements` in the `e2e` configuration of `frontend/angular.json`, pointing at `e2e/stubs/*`. Covering a new native capability means adding a stub plus a `fileReplacements` entry — do not fake it inside the spec.
+- Binary fixtures live in `e2e/assets/`.
+
+## Waiting and assertions
+
+- Rely on auto-waiting `expect(locator).toBeVisible()` and `page.waitForURL(...)`. Never use `page.waitForTimeout()`.
+- To assert what the app sent, register `page.waitForResponse(...)` before the click that triggers the request, then inspect `request().postDataJSON()`.
+- Assert what the user can observe plus outgoing request payloads. Do not reach into NGXS state or component internals.
+- Keep specs independent and deterministic: no shared state or ordering assumptions between tests.


### PR DESCRIPTION
Codify existing frontend, backend, contracts, MongoDB, NGXS, and testing conventions so the agent follows project patterns instead of inventing generic ones.