### PR TITLE
test: P2 auth, files, and Playwright task flows

### DIFF
--- a/backend/src/modules/files/router.ts
+++ b/backend/src/modules/files/router.ts
@@ -1,8 +1,9 @@
-import { Router } from 'express';
+import { Router, NextFunction, Request, Response } from 'express';
 import multer from 'multer';
 import { uploadImageController } from './usecases/upload-image/_index.js';
 import { getImageController } from './usecases/get-image/_index.js';
 import { MAX_IMAGE_UPLOAD_FILE_BYTES } from './config.js';
+import { BaseController } from '../../shared/infra/http/models/base-controller.js';
 
 const filesRouter: Router = Router();
 
@@ -16,5 +17,15 @@ filesRouter.post('/image', uploader.single('file'), (req, res, next) =>
 );
 
 filesRouter.get('/image/:imageId', (req, res, next) => getImageController.execute(req, res, next));
+
+filesRouter.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {
+  if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+    return BaseController.jsonResponse(res, 413, {
+      name: 'FILE_TOO_LARGE',
+      message: `File exceeds the maximum size of ${MAX_IMAGE_UPLOAD_FILE_BYTES} bytes`,
+    });
+  }
+  return next(err);
+});
 
 export { filesRouter };

--- a/backend/test/integration/_setup/auth.helper.ts
+++ b/backend/test/integration/_setup/auth.helper.ts
@@ -76,3 +76,13 @@ export function authenticatedRequest(app: Application, jwtCookie: string): {
     delete: (url: string) => request(app).delete(url).set('Cookie', cookie),
   };
 }
+
+export function jwtCookieFromResponse(res: { headers: { [key: string]: unknown } }): string {
+  const raw = res.headers['set-cookie'];
+  const list = Array.isArray(raw) ? raw : typeof raw === 'string' ? [raw] : [];
+  const jwtSetCookie = list.find((cookie: string) => cookie.startsWith('jwt='));
+  if (!jwtSetCookie) {
+    throw new Error(`No jwt Set-Cookie in: ${JSON.stringify(list)}`);
+  }
+  return jwtSetCookie.split(';')[0];
+}

--- a/backend/test/integration/auth/login.int.spec.ts
+++ b/backend/test/integration/auth/login.int.spec.ts
@@ -1,0 +1,96 @@
+import { Application } from 'express';
+import request from 'supertest';
+import { TaskDTO } from '@brainassistant/contracts';
+import UserModel from '../../../src/shared/infra/database/mongodb/user.model.js';
+import {
+  authenticatedRequest,
+  jwtCookieFromResponse,
+} from '../_setup/auth.helper.js';
+import { buildTestApp } from '../_setup/build-test-app.js';
+import { clearDatabase, startInMemoryMongo, stopInMemoryMongo } from '../_setup/mongo-memory.js';
+
+describe('Integration: Login (Controller -> UseCase -> Repo -> MongoDB)', () => {
+  let app: Application;
+
+  const signupBody = {
+    email: 'login.user@example.com',
+    firstName: 'Login',
+    lastName: 'User',
+    password: 'password123',
+  };
+
+  beforeAll(async () => {
+    await startInMemoryMongo();
+    app = buildTestApp().app;
+  }, 30_000);
+
+  afterAll(async () => {
+    await stopInMemoryMongo();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+  });
+
+  it('rejects login when the account is not verified', async () => {
+    await request(app).post('/api/auth/signup').send(signupBody);
+
+    const res = await request(app).post('/api/auth/login').send({
+      username: signupBody.email,
+      password: signupBody.password,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body.message).toBe('User account not verified!');
+  });
+
+  it('rejects login with a wrong password', async () => {
+    await request(app).post('/api/auth/signup').send(signupBody);
+    await UserModel.updateOne({ username: signupBody.email }, { $set: { verified: true } });
+
+    const res = await request(app).post('/api/auth/login').send({
+      username: signupBody.email,
+      password: 'wrong-password',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body.message).toBe('Authorization failed!');
+  });
+
+  it('happy path: sets a jwt cookie that can call a protected route', async () => {
+    await request(app).post('/api/auth/signup').send(signupBody);
+    await UserModel.updateOne({ username: signupBody.email }, { $set: { verified: true } });
+
+    const res = await request(app).post('/api/auth/login').send({
+      username: signupBody.email,
+      password: signupBody.password,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({
+      email: signupBody.email,
+      firstName: signupBody.firstName,
+      lastName: signupBody.lastName,
+    });
+    expect(res.body.user.userId).toBeTruthy();
+
+    const jwtCookie = jwtCookieFromResponse(res);
+    const taskRes = await authenticatedRequest(app, jwtCookie)
+      .post('/api/sync/task')
+      .send({
+        changeableObjectDto: {
+          id: 'task-from-login',
+          type: 'TASK',
+          title: 'Created after login',
+          status: 'OPEN',
+        },
+      })
+      .set('Accept', 'application/json');
+
+    expect(taskRes.status).toBe(201);
+    const task: TaskDTO = taskRes.body;
+    expect(task.userId).toBe(res.body.user.userId);
+  });
+});

--- a/backend/test/integration/auth/signup.int.spec.ts
+++ b/backend/test/integration/auth/signup.int.spec.ts
@@ -1,0 +1,71 @@
+import { Application } from 'express';
+import request from 'supertest';
+import { models } from '../../../src/shared/infra/database/mongodb/index.js';
+import { buildTestApp } from '../_setup/build-test-app.js';
+import { clearDatabase, startInMemoryMongo, stopInMemoryMongo } from '../_setup/mongo-memory.js';
+
+describe('Integration: SignUp (Controller -> UseCase -> Repo -> MongoDB)', () => {
+  let app: Application;
+
+  const validSignup = {
+    email: 'new.user@example.com',
+    firstName: 'New',
+    lastName: 'User',
+    password: 'password123',
+  };
+
+  beforeAll(async () => {
+    await startInMemoryMongo();
+    app = buildTestApp().app;
+  }, 30_000);
+
+  afterAll(async () => {
+    await stopInMemoryMongo();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+  });
+
+  it('happy path: creates an unverified user and does not send email', async () => {
+    const res = await request(app).post('/api/auth/signup').send(validSignup);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      email: validSignup.email,
+      firstName: validSignup.firstName,
+      lastName: validSignup.lastName,
+    });
+
+    const persisted = await models.UserModel.findOne({ username: validSignup.email }).lean();
+    expect(persisted).toMatchObject({
+      username: validSignup.email,
+      firstName: validSignup.firstName,
+      lastName: validSignup.lastName,
+      verified: false,
+    });
+  });
+
+  it('invalid email -> 400 and no user persisted', async () => {
+    const res = await request(app).post('/api/auth/signup').send({
+      ...validSignup,
+      email: 'not-an-email',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body).toHaveProperty('message');
+    expect(await models.UserModel.countDocuments()).toBe(0);
+  });
+
+  it('duplicate email -> 409', async () => {
+    await request(app).post('/api/auth/signup').send(validSignup);
+
+    const res = await request(app).post('/api/auth/signup').send(validSignup);
+
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body).toHaveProperty('message');
+    expect(await models.UserModel.countDocuments()).toBe(1);
+  });
+});

--- a/backend/test/integration/files/get-image.int.spec.ts
+++ b/backend/test/integration/files/get-image.int.spec.ts
@@ -1,0 +1,121 @@
+import path from 'path';
+import { createReadStream } from 'fs';
+import { Application } from 'express';
+import request from 'supertest';
+import sharp from 'sharp';
+import { googleDriveService } from '../../../src/modules/integrations/google/services/index.js';
+import { authenticatedRequest, seedTestUser } from '../_setup/auth.helper.js';
+import { buildTestApp } from '../_setup/build-test-app.js';
+import { clearDatabase, startInMemoryMongo, stopInMemoryMongo } from '../_setup/mongo-memory.js';
+
+describe('Integration: GetImage (Controller -> UseCase -> Repo -> MongoDB)', () => {
+  let app: Application;
+  const TEST_IMAGE_PATH = path.join(process.cwd(), 'test/integration/_fixtures/test-img.jpg');
+  const drive = googleDriveService as unknown as {
+    uploadFile: jest.Mock;
+    getImageById: jest.Mock;
+  };
+
+  beforeAll(async () => {
+    await startInMemoryMongo();
+    app = buildTestApp().app;
+  }, 30_000);
+
+  afterAll(async () => {
+    await stopInMemoryMongo();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+    jest.clearAllMocks();
+    drive.uploadFile.mockResolvedValue('google-drive-file-id');
+    drive.getImageById.mockImplementation(async () => ({
+      data: createReadStream(TEST_IMAGE_PATH),
+      headers: { 'content-type': 'image/jpeg' },
+      status: 200,
+      statusText: 'OK',
+      config: {},
+    }));
+  });
+
+  it('returns 401 without auth cookie', async () => {
+    const res = await request(app).get('/api/files/image/image-unauth');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when the image is not in the database', async () => {
+    const { jwtCookie } = await seedTestUser();
+
+    const res = await authenticatedRequest(app, jwtCookie).get('/api/files/image/missing-image');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body).toHaveProperty('message');
+    expect(drive.getImageById).not.toHaveBeenCalled();
+  });
+
+  it('streams the image from Drive after a successful upload', async () => {
+    const { jwtCookie } = await seedTestUser();
+    const imageId = 'image-get-1';
+    await uploadFixture(app, jwtCookie, imageId);
+
+    const res = await getImageBuffer(app, jwtCookie, imageId);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/image\/jpeg/);
+    expect(drive.getImageById).toHaveBeenCalledTimes(1);
+    const meta = await sharp(res.body).metadata();
+    expect(meta.format).toBe('jpeg');
+    expect(meta.width).toBeGreaterThan(0);
+  });
+
+  it('resizes the image when width is requested', async () => {
+    const { jwtCookie } = await seedTestUser();
+    const imageId = 'image-get-resize';
+    await uploadFixture(app, jwtCookie, imageId);
+
+    const original = await sharp(TEST_IMAGE_PATH).metadata();
+    const requestedWidth = 40;
+    const res = await getImageBuffer(app, jwtCookie, imageId, requestedWidth);
+
+    expect(res.status).toBe(200);
+    const meta = await sharp(res.body).metadata();
+    expect(meta.width).toBe(requestedWidth);
+    expect(original.width).toBeGreaterThan(requestedWidth);
+  });
+});
+
+async function uploadFixture(app: Application, jwtCookie: string, imageId: string): Promise<void> {
+  const TEST_IMAGE_PATH = path.join(process.cwd(), 'test/integration/_fixtures/test-img.jpg');
+  const res = await authenticatedRequest(app, jwtCookie)
+    .post('/api/files/image')
+    .field('imageId', imageId)
+    .attach('file', TEST_IMAGE_PATH);
+
+  if (res.status !== 200) {
+    throw new Error(`Upload fixture failed: ${res.status} ${JSON.stringify(res.body)}`);
+  }
+}
+
+function getImageBuffer(
+  app: Application,
+  jwtCookie: string,
+  imageId: string,
+  width?: number,
+): Promise<request.Response> {
+  let req = authenticatedRequest(app, jwtCookie).get(`/api/files/image/${imageId}`);
+  if (width !== undefined) {
+    req = req.query({ width: String(width) });
+  }
+  return req.buffer(true).parse(collectBinary as never);
+}
+
+function collectBinary(
+  res: { on: (event: string, listener: (chunk: Buffer) => void) => void },
+  callback: (err: Error | null, body: Buffer) => void,
+): void {
+  const chunks: Buffer[] = [];
+  res.on('data', (chunk: Buffer) => chunks.push(chunk));
+  res.on('end', () => callback(null, Buffer.concat(chunks)));
+}

--- a/backend/test/integration/files/upload-image.int.spec.ts
+++ b/backend/test/integration/files/upload-image.int.spec.ts
@@ -3,6 +3,7 @@ import { promises as fsp } from 'fs';
 import { Application } from 'express';
 import request from 'supertest';
 import { googleDriveService } from '../../../src/modules/integrations/google/services/index.js';
+import { MAX_IMAGE_UPLOAD_FILE_BYTES } from '../../../src/modules/files/config.js';
 import { models } from '../../../src/shared/infra/database/mongodb/index.js';
 import { authenticatedRequest, seedTestUser } from '../_setup/auth.helper.js';
 import { buildTestApp } from '../_setup/build-test-app.js';
@@ -98,5 +99,20 @@ describe('Integration: UploadImage (Controller -> UseCase -> Repo -> MongoDB)', 
 
     const persistedImage = await models.ImageModel.findOne({ imageId }).lean();
     expect(persistedImage).toBeNull();
+  });
+
+  it('rejects a file larger than MAX_IMAGE_UPLOAD_FILE_BYTES', async () => {
+    const { jwtCookie } = await seedTestUser();
+    const oversized = Buffer.alloc(MAX_IMAGE_UPLOAD_FILE_BYTES + 1);
+
+    const res = await authenticatedRequest(app, jwtCookie)
+      .post('/api/files/image')
+      .field('imageId', 'image-too-big')
+      .attach('file', oversized, { filename: 'huge.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toMatchObject({ name: 'FILE_TOO_LARGE' });
+    expect(res.body).toHaveProperty('message');
+    expect(await models.ImageModel.findOne({ imageId: 'image-too-big' }).lean()).toBeNull();
   });
 });

--- a/frontend/e2e/delete-task.spec.ts
+++ b/frontend/e2e/delete-task.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { setupApiMocks } from './utils/api-mocks.util';
+import { createTaskWithTitle, signIn } from './utils/task-flow.util';
+
+test('user can delete a task', async ({ page }) => {
+  await setupApiMocks(page);
+  await signIn(page);
+  await createTaskWithTitle(page, 'Task to delete');
+
+  await page.locator('[data-test="task-tile"]', { hasText: 'Task to delete' }).click();
+  await page.waitForURL(/\/task\/TASK_VIEW_MODE_VIEW\//);
+
+  await page.click('[data-test="task-options-btn"]');
+
+  const deletePromise = page.waitForResponse(
+    response =>
+      response.url().includes('/api/sync/task') && response.request().method() === 'DELETE',
+  );
+  await page.click('[data-test="task-menu-delete"]');
+  await deletePromise;
+
+  await page.waitForURL(/\/(home)?$/);
+  await expect(page.locator('[data-test="task-tile"]', { hasText: 'Task to delete' })).toHaveCount(0);
+});

--- a/frontend/e2e/edit-task.spec.ts
+++ b/frontend/e2e/edit-task.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import type { SendChangeContract, TaskDTO } from '@brainassistant/contracts';
+import { setupApiMocks } from './utils/api-mocks.util';
+import { createTaskWithTitle, signIn } from './utils/task-flow.util';
+
+test('user can edit a task title', async ({ page }) => {
+  await setupApiMocks(page);
+  await signIn(page);
+  await createTaskWithTitle(page, 'Original task title');
+
+  await page.locator('[data-test="task-tile"]', { hasText: 'Original task title' }).click();
+  await page.waitForURL(/\/task\/TASK_VIEW_MODE_VIEW\//);
+  await expect(page.locator('[data-test="task-view-title"]')).toHaveText('Original task title');
+
+  await page.click('[data-test="task-options-btn"]');
+  await page.click('[data-test="task-menu-edit"]');
+  await page.fill('[data-test="task-title-input"]', 'Edited task title');
+
+  const applyButton = page.locator('[data-test="apply-changes-btn"]');
+  await expect(applyButton).toBeEnabled();
+
+  const patchPromise = page.waitForResponse(
+    response =>
+      response.url().includes('/api/sync/task') && response.request().method() === 'PATCH',
+  );
+  await applyButton.click();
+  const patchResponse = await patchPromise;
+
+  const patchBody = patchResponse.request().postDataJSON() as SendChangeContract.Request<TaskDTO>;
+  expect(patchBody.changeableObjectDto).toBeTruthy();
+  expect(patchBody.changeableObjectDto.title).toBe('Edited task title');
+
+  await expect(page.locator('[data-test="task-view-title"]')).toHaveText('Edited task title');
+
+  await page.click('[data-test="go-home-btn"]');
+  await page.waitForURL(/\/(home)?$/);
+  await expect(page.locator('[data-test="task-tile"]', { hasText: 'Edited task title' })).toBeVisible();
+  await expect(page.locator('[data-test="task-tile"]', { hasText: 'Original task title' })).toHaveCount(0);
+});

--- a/frontend/e2e/sync-error.spec.ts
+++ b/frontend/e2e/sync-error.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import { setupApiMocks } from './utils/api-mocks.util';
+import { createTaskWithTitle, signIn } from './utils/task-flow.util';
+
+test('task stays on home when sync to the server fails', async ({ page }) => {
+  await setupApiMocks(page, { failTaskSync: true });
+  await signIn(page);
+
+  const postResponse = await createTaskWithTitle(page, 'Unsynced task title');
+  expect(postResponse.status()).toBe(500);
+
+  await expect(page.locator('[data-test="task-tile"]', { hasText: 'Unsynced task title' })).toBeVisible();
+});

--- a/frontend/e2e/utils/api-mocks.util.ts
+++ b/frontend/e2e/utils/api-mocks.util.ts
@@ -1,43 +1,92 @@
 import { Page } from '@playwright/test';
+import type {
+  ApiErrorDto,
+  GetChangesContract,
+  SendChangeContract,
+  TaskDTO,
+  UploadImageContract,
+} from '@brainassistant/contracts';
+
+export type SetupApiMocksOptions = {
+  /** POST /api/sync/task returns 500; the task stays in the client sync queue. */
+  failTaskSync?: boolean;
+};
+
+type ReleaseClientIdResponse = { clientId: string };
+
+function json(status: number, body: unknown) {
+  return {
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  };
+}
+
+function parseSendChangeTask(postData: string | null): TaskDTO | null {
+  if (!postData) {
+    return null;
+  }
+  try {
+    const body = JSON.parse(postData) as SendChangeContract.Request<TaskDTO>;
+    return body.changeableObjectDto ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
- * Sets up API route mocks for E2E testing
- * Mocks all backend API endpoints to allow testing without a running backend
- * @param page - Playwright page instance
+ * Mocks backend API routes so E2E specs run without a live server.
  */
-export async function setupApiMocks(page: Page): Promise<void> {
-  await page.route('**/api/**', async (route) => {
+export async function setupApiMocks(
+  page: Page,
+  options: SetupApiMocksOptions = {},
+): Promise<void> {
+  await page.route('**/api/**', async route => {
     const request = route.request();
     const url = request.url();
     const method = request.method();
-    
+
     if (url.includes('/api/sync/release-client-id')) {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ clientId: 'mock-client-id-123' })
-      });
-    } else if (url.includes('/api/sync/changes') && method === 'GET') {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ changes: [] })
-      });
-    } else if (url.includes('/api/sync/task') && method === 'POST') {
-      await route.fulfill({
-        status: 201,
-        contentType: 'application/json',
-        body: JSON.stringify({ success: true })
-      });
-    } else if (url.includes('/api/files/image') && method === 'POST') {
-      await route.fulfill({
-        status: 201,
-        contentType: 'application/json',
-        body: JSON.stringify({ imageId: 'mock-uploaded-image-id' })
-      });
-    } else {
-      await route.continue();
+      const body: ReleaseClientIdResponse = { clientId: 'mock-client-id-123' };
+      await route.fulfill(json(200, body));
+      return;
     }
+
+    if (url.includes('/api/sync/changes') && method === 'GET') {
+      const body: GetChangesContract.Response = { changes: [] };
+      await route.fulfill(json(200, body));
+      return;
+    }
+
+    if (url.includes('/api/sync/task') && method === 'POST') {
+      if (options.failTaskSync) {
+        const body: ApiErrorDto = { name: 'InternalError', message: 'sync failed' };
+        await route.fulfill(json(500, body));
+        return;
+      }
+      const task = parseSendChangeTask(request.postData());
+      const body: SendChangeContract.Response<TaskDTO> = task ?? undefined;
+      await route.fulfill(json(201, body ?? {}));
+      return;
+    }
+
+    if (url.includes('/api/sync/task') && method === 'PATCH') {
+      const task = parseSendChangeTask(request.postData());
+      await route.fulfill(json(200, task ?? {}));
+      return;
+    }
+
+    if (url.includes('/api/sync/task') && method === 'DELETE') {
+      await route.fulfill(json(200, {}));
+      return;
+    }
+
+    if (url.includes('/api/files/image') && method === 'POST') {
+      const body: UploadImageContract.Response = { imageId: 'mock-uploaded-image-id' };
+      await route.fulfill(json(201, body));
+      return;
+    }
+
+    await route.continue();
   });
 }
-

--- a/frontend/e2e/utils/task-flow.util.ts
+++ b/frontend/e2e/utils/task-flow.util.ts
@@ -1,0 +1,29 @@
+import { expect, type Page, type Response } from '@playwright/test';
+
+export async function signIn(page: Page): Promise<void> {
+  await page.goto('/');
+  await expect(page.getByText('Sign in with Google')).toBeVisible();
+  await page.click('text=Sign in with Google');
+  await expect(page.getByText('Sign in with Google')).not.toBeVisible();
+  await expect(page.locator('[data-test="new-task-btn"]')).toBeVisible();
+}
+
+export async function createTaskWithTitle(page: Page, title: string): Promise<Response> {
+  await page.click('[data-test="new-task-btn"]');
+  await page.waitForURL('/task/TASK_VIEW_MODE_CREATE');
+  await page.fill('[data-test="task-title-input"]', title);
+
+  const applyButton = page.locator('[data-test="apply-changes-btn"]');
+  await expect(applyButton).toBeEnabled();
+
+  const postPromise = page.waitForResponse(
+    response => response.url().includes('/api/sync/task') && response.request().method() === 'POST',
+  );
+  await applyButton.click();
+  const postResponse = await postPromise;
+
+  await page.waitForURL(/\/(home)?$/);
+  await expect(page.locator('[data-test="task-tile"]', { hasText: title })).toBeVisible();
+
+  return postResponse;
+}

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -33,7 +33,10 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 375, height: 667 },
+      },
     },
     // Uncomment to test in other browsers
     // {

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-bottom-panel/mb-task-bottom-panel.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-bottom-panel/mb-task-bottom-panel.component.html
@@ -16,7 +16,7 @@
 }
 
 @if (mode() === ETaskViewMode.View) {
-  <div class="go-home-btn" (click)="goHome()">
+  <div class="go-home-btn" (click)="goHome()" data-test="go-home-btn">
     <img src="assets/ui/icons/home-icon.png" />
   </div>
 }

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-side-menu/mb-task-side-menu-item/mb-task-side-menu-item.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-side-menu/mb-task-side-menu-item/mb-task-side-menu-item.component.html
@@ -1,4 +1,8 @@
-<div class="sidemenu-item sidemenu-cancel-btn" (click)="optionItem().callback()">
+<div
+  class="sidemenu-item sidemenu-cancel-btn"
+  (click)="optionItem().callback()"
+  [attr.data-test]="'task-menu-' + optionItem().label.toLowerCase()"
+>
   <img class="sidemenu-item-icon" src="{{ optionItem().icon }}" />
   <span>{{ optionItem().label }}</span>
 </div>

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-top-panel/mb-task-top-panel.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-top-panel/mb-task-top-panel.component.html
@@ -3,5 +3,10 @@
 }
 
 @if (showToggleOptionsBtn$ | async) {
-  <div class="top-panel-btn options" (click)="toggleMenu()" id="toggelOptionsMenuBtn"></div>
+  <div
+    class="top-panel-btn options"
+    (click)="toggleMenu()"
+    id="toggelOptionsMenuBtn"
+    data-test="task-options-btn"
+  ></div>
 }

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.html
@@ -1,6 +1,6 @@
 @let task = task$ | async;
 <div class="title-holder">
-  <span>{{ task.title }}</span>
+  <span data-test="task-view-title">{{ task.title }}</span>
 </div>
 @if (task?.imageId) {
   <div class="task-picture-holder">


### PR DESCRIPTION
## Summary
- Signup/login integration on the JWT harness: unverified and failed login, then a real login cookie can create a task.
- GetImage streams and resizes against a Drive stub; oversized uploads return 413 `FILE_TOO_LARGE` from the files router (multer rejects before the use-case).
- Playwright: API mocks typed against contracts, edit/delete task flows, optimistic UI when `POST /api/sync/task` returns 500, viewport 375.

## Test plan
- [ ] `cd backend; npm test` — auth signup/login and files get-image / oversized upload
- [ ] `cd frontend; npm run e2e` — create, edit, delete, and sync-error specs

Made with [Cursor](https://cursor.com)