### PR TITLE
test: P3 Slack, STT, compose-smoke, and Google FakeStrategy

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -1,0 +1,23 @@
+name: Compose Smoke
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run compose smoke
+        run: node scripts/smoke/run.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/*
 nginx/ssl/*
+scripts/smoke/certs/
 
 # evirament variables
 .env

--- a/backend/src/modules/integrations/slack/middleware/verification-challenge.function.ts
+++ b/backend/src/modules/integrations/slack/middleware/verification-challenge.function.ts
@@ -15,39 +15,44 @@ export function verificationChallenge() {
     const xSlackRequestTimestamp = req.headers['x-slack-request-timestamp'];
     const contentType = req.headers['content-type'];
 
+    if (!xSlackSignatur || !xSlackRequestTimestamp) {
+      return res.status(400).send('Verifying requests from Slack failed');
+    }
+
     let rawBody;
-    if (
-      contentType?.toLocaleLowerCase() === 'application/x-www-form-urlencoded'
-    ) {
+    if (contentType?.toLocaleLowerCase() === 'application/x-www-form-urlencoded') {
       rawBody = formurlencoded(req.body);
     } else {
       rawBody = JSON.stringify(req.body)
         .replace(/\//g, '\\/')
         .replace(
           /[\u007f-\uffff]/g,
-          (c) => '\\u' + ('0000' + c.charCodeAt(0).toString(16)).slice(-4)
+          c => '\\u' + ('0000' + c.charCodeAt(0).toString(16)).slice(-4),
         );
+    }
+
+    const signingSecret = process.env.SLACK_SIGNING_SECRET;
+    if (!signingSecret) {
+      return res.status(400).send('Verifying requests from Slack failed');
     }
 
     const sigBasestring = `v0:${xSlackRequestTimestamp}:${rawBody}`;
     const mySignature =
-      'v0=' +
-      crypto
-        .createHmac('sha256', process.env.SLACK_SIGNING_SECRET)
-        .update(sigBasestring)
-        .digest('hex');
+      'v0=' + crypto.createHmac('sha256', signingSecret).update(sigBasestring).digest('hex');
 
-    if (
-      crypto.timingSafeEqual(
-        Buffer.from(mySignature, 'utf8'),
-        Buffer.from(xSlackSignatur, 'utf8')
-      )
-    ) {
-      next();
-    } else {
-      return res.status(400).send('Verifying requests from Slack failed');
+    try {
+      if (
+        crypto.timingSafeEqual(
+          Buffer.from(mySignature, 'utf8'),
+          Buffer.from(xSlackSignatur, 'utf8'),
+        )
+      ) {
+        return next();
+      }
+    } catch {
+      // timingSafeEqual throws when buffer lengths differ
     }
 
-    return next();
+    return res.status(400).send('Verifying requests from Slack failed');
   };
 }

--- a/backend/test/README.md
+++ b/backend/test/README.md
@@ -19,13 +19,25 @@ test/
     │   ├── mongo-memory.ts
     │   ├── build-test-app.ts            # production createApp(), no Mongo bootstrap
     │   ├── auth.helper.ts               # seedTestUser + authenticatedRequest
+    │   ├── slack.helper.ts              # HMAC for x-slack-signature
     │   └── harness.smoke.spec.ts
     ├── _fixtures/
     │   └── test-img.jpg
+    ├── ai/
+    │   └── speech-to-text.int.spec.ts   # POST /api/ai/speech-to-text (OpenAI mocked)
+    ├── auth/
+    │   ├── signup.int.spec.ts
+    │   └── login.int.spec.ts
     ├── files/
-    │   └── upload-image.int.spec.ts     # POST /api/files/image
+    │   ├── upload-image.int.spec.ts
+    │   └── get-image.int.spec.ts
+    ├── integrations/
+    │   └── slack-event-received.int.spec.ts  # POST /api/integrations/slack/event-recived
     └── sync/
-        └── task-create.int.spec.ts      # POST /api/sync/task
+        ├── task-create.int.spec.ts
+        ├── task-update.int.spec.ts
+        ├── task-delete.int.spec.ts
+        └── get-changes.int.spec.ts
 ```
 
 Specs are named `<use-case>.int.spec.ts` and described as `Integration: CreateTask (Controller -> UseCase -> Repo -> MongoDB)`. Folders under `integration/` follow `src/modules/<module>/usecases/`. Imports use the `.js` extension, same as production ESM.
@@ -82,7 +94,7 @@ They live in `test/unit/`, named `<subject>.spec.ts`, and call the real class.
 
 ## Environment
 
-`setup-env.ts` (Jest `setupFiles`) sets `AUTHENTICATION_STRATEGY=JWT`, `JWT_SECRET`, `FILES_UPLOAD_PATH`, and dummy Google / SendGrid / Mailgun / OpenAI keys so `createApp()` can boot without `.env`.
+`setup-env.ts` (Jest `setupFiles`) sets `AUTHENTICATION_STRATEGY=JWT`, `JWT_SECRET`, `FILES_UPLOAD_PATH`, `SLACK_SIGNING_SECRET`, and dummy Google / SendGrid / Mailgun / OpenAI keys so `createApp()` can boot without `.env`.
 
 ## CI
 

--- a/backend/test/README.md
+++ b/backend/test/README.md
@@ -20,6 +20,7 @@ test/
     │   ├── build-test-app.ts            # production createApp(), no Mongo bootstrap
     │   ├── auth.helper.ts               # seedTestUser + authenticatedRequest
     │   ├── slack.helper.ts              # HMAC for x-slack-signature
+    │   ├── fake-google.strategy.ts      # Passport `google` stub (no real Google)
     │   └── harness.smoke.spec.ts
     ├── _fixtures/
     │   └── test-img.jpg
@@ -27,7 +28,8 @@ test/
     │   └── speech-to-text.int.spec.ts   # POST /api/ai/speech-to-text (OpenAI mocked)
     ├── auth/
     │   ├── signup.int.spec.ts
-    │   └── login.int.spec.ts
+    │   ├── login.int.spec.ts
+    │   └── google-auth.int.spec.ts     # GET /api/integrations/google/auth (FakeStrategy)
     ├── files/
     │   ├── upload-image.int.spec.ts
     │   └── get-image.int.spec.ts

--- a/backend/test/integration/_setup/fake-google.strategy.ts
+++ b/backend/test/integration/_setup/fake-google.strategy.ts
@@ -1,0 +1,62 @@
+import passport from 'passport';
+import { Strategy } from 'passport-strategy';
+import type { Profile } from 'passport-google-oauth20';
+import type { GoogleProfileWithTokens } from '../../../src/shared/infra/auth/google.strategy.js';
+
+export type FakeGoogleOutcome =
+  | { type: 'success'; value: GoogleProfileWithTokens }
+  | { type: 'error'; error: Error };
+
+/**
+ * Passport strategy named `google` that never talks to Google.
+ * Swap it in after createApp() so GoogleAuthUsecase still runs for real.
+ */
+export class FakeGoogleStrategy extends Strategy {
+  name = 'google';
+
+  constructor(private readonly outcome: FakeGoogleOutcome) {
+    super();
+  }
+
+  authenticate(): void {
+    if (this.outcome.type === 'error') {
+      this.error(this.outcome.error);
+      return;
+    }
+    this.success(this.outcome.value);
+  }
+}
+
+export function installFakeGoogleStrategy(outcome: FakeGoogleOutcome): void {
+  passport.unuse('google');
+  passport.use(new FakeGoogleStrategy(outcome));
+}
+
+export function fakeGoogleSuccess(options?: {
+  googleId?: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  accessToken?: string;
+  refreshToken?: string | undefined;
+}): GoogleProfileWithTokens {
+  const email = options?.email ?? 'google.user@example.com';
+  const profile = {
+    id: options?.googleId ?? 'google-id-1',
+    provider: 'google',
+    displayName: `${options?.firstName ?? 'Google'} ${options?.lastName ?? 'User'}`,
+    _json: {
+      email,
+      given_name: options?.firstName ?? 'Google',
+      family_name: options?.lastName ?? 'User',
+    },
+  } as Profile;
+
+  return {
+    profile,
+    tokens: {
+      accessToken: options?.accessToken ?? 'google-access-token',
+      refreshToken: options?.refreshToken === undefined ? 'google-refresh-token' : options.refreshToken,
+    },
+  };
+}

--- a/backend/test/integration/_setup/slack.helper.ts
+++ b/backend/test/integration/_setup/slack.helper.ts
@@ -1,0 +1,23 @@
+import crypto from 'crypto';
+
+/**
+ * Signs a JSON body the same way verification-challenge.function.ts does
+ * after express.json() has already parsed the payload.
+ */
+export function slackSignatureForBody(
+  body: unknown,
+  timestamp: string,
+  secret = process.env.SLACK_SIGNING_SECRET ?? 'test-slack-signing-secret',
+): string {
+  const rawBody = JSON.stringify(body)
+    .replace(/\//g, '\\/')
+    .replace(
+      /[\u007f-\uffff]/g,
+      c => '\\u' + ('0000' + c.charCodeAt(0).toString(16)).slice(-4),
+    );
+
+  return (
+    'v0=' +
+    crypto.createHmac('sha256', secret).update(`v0:${timestamp}:${rawBody}`).digest('hex')
+  );
+}

--- a/backend/test/integration/ai/speech-to-text.int.spec.ts
+++ b/backend/test/integration/ai/speech-to-text.int.spec.ts
@@ -1,0 +1,94 @@
+import { Application } from 'express';
+import request from 'supertest';
+import { Result } from '../../../src/shared/core/result.js';
+import { OpenAIClientService } from '../../../src/modules/ai/services/open-ai-client.service.js';
+import { authenticatedRequest, seedTestUser } from '../_setup/auth.helper.js';
+import { buildTestApp } from '../_setup/build-test-app.js';
+import { clearDatabase, startInMemoryMongo, stopInMemoryMongo } from '../_setup/mongo-memory.js';
+
+describe('Integration: SpeechToText (Controller -> UseCase -> OpenAI mock)', () => {
+  let app: Application;
+  let createTranscription: jest.Mock;
+
+  beforeAll(async () => {
+    await startInMemoryMongo();
+    app = buildTestApp().app;
+  }, 30_000);
+
+  afterAll(async () => {
+    await stopInMemoryMongo();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+    jest.restoreAllMocks();
+    createTranscription = jest.fn().mockResolvedValue({ text: 'hello from whisper' });
+    jest.spyOn(OpenAIClientService.prototype, 'getClientOrFail').mockReturnValue(
+      Result.ok({
+        audio: {
+          transcriptions: {
+            create: createTranscription,
+          },
+        },
+      } as never),
+    );
+  });
+
+  it('returns 401 without auth cookie', async () => {
+    const res = await request(app)
+      .post('/api/ai/speech-to-text')
+      .attach('file', Buffer.from('fake-audio'), {
+        filename: 'clip.webm',
+        contentType: 'audio/webm',
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns transcript when OpenAI succeeds', async () => {
+    const { jwtCookie } = await seedTestUser();
+
+    const res = await authenticatedRequest(app, jwtCookie)
+      .post('/api/ai/speech-to-text')
+      .attach('file', Buffer.from('fake-audio-bytes'), {
+        filename: 'clip.webm',
+        contentType: 'audio/webm',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ transcript: 'hello from whisper' });
+    expect(createTranscription).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 for an unsupported audio mime type', async () => {
+    const { jwtCookie } = await seedTestUser();
+
+    const res = await authenticatedRequest(app, jwtCookie)
+      .post('/api/ai/speech-to-text')
+      .attach('file', Buffer.from('not-audio'), {
+        filename: 'notes.txt',
+        contentType: 'text/plain',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body.message).toContain('Unsupported media type');
+    expect(createTranscription).not.toHaveBeenCalled();
+  });
+
+  it('returns 502 when OpenAI transcription fails', async () => {
+    createTranscription.mockRejectedValue(new Error('openai down'));
+    const { jwtCookie } = await seedTestUser();
+
+    const res = await authenticatedRequest(app, jwtCookie)
+      .post('/api/ai/speech-to-text')
+      .attach('file', Buffer.from('fake-audio-bytes'), {
+        filename: 'clip.webm',
+        contentType: 'audio/webm',
+      });
+
+    expect(res.status).toBe(502);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body.message).toContain('OpenAI transcription API Request Failed');
+  });
+});

--- a/backend/test/integration/auth/google-auth.int.spec.ts
+++ b/backend/test/integration/auth/google-auth.int.spec.ts
@@ -1,0 +1,152 @@
+import { Application } from 'express';
+import request from 'supertest';
+import UserModel from '../../../src/shared/infra/database/mongodb/user.model.js';
+import {
+  authenticatedRequest,
+  jwtCookieFromResponse,
+  seedTestUser,
+} from '../_setup/auth.helper.js';
+import { buildTestApp } from '../_setup/build-test-app.js';
+import {
+  fakeGoogleSuccess,
+  installFakeGoogleStrategy,
+} from '../_setup/fake-google.strategy.js';
+import { clearDatabase, startInMemoryMongo, stopInMemoryMongo } from '../_setup/mongo-memory.js';
+
+const AUTH_PATH = '/api/integrations/google/auth';
+
+describe('Integration: GoogleAuth (Controller -> UseCase -> Repo -> MongoDB)', () => {
+  let app: Application;
+
+  beforeAll(async () => {
+    await startInMemoryMongo();
+    app = buildTestApp().app;
+  }, 30_000);
+
+  afterAll(async () => {
+    await stopInMemoryMongo();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+  });
+
+  it('creates a verified Google user, sets a jwt cookie, and can create a task', async () => {
+    installFakeGoogleStrategy({
+      type: 'success',
+      value: fakeGoogleSuccess({
+        googleId: 'g-new-1',
+        email: 'new.google@example.com',
+      }),
+    });
+
+    const res = await request(app).get(AUTH_PATH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({
+      email: 'new.google@example.com',
+      firstName: 'Google',
+      lastName: 'User',
+    });
+    expect(res.body.user.userId).toBeTruthy();
+
+    const stored = await UserModel.findOne({ username: 'new.google@example.com' });
+    expect(stored).toBeTruthy();
+    expect(stored!.verified).toBe(true);
+    expect(stored!.googleId).toBe('g-new-1');
+    expect(stored!.googleRefreshToken).toBe('google-refresh-token');
+
+    const jwtCookie = jwtCookieFromResponse(res);
+    const taskRes = await authenticatedRequest(app, jwtCookie)
+      .post('/api/sync/task')
+      .send({
+        changeableObjectDto: {
+          id: 'task-from-google',
+          type: 'TASK',
+          title: 'Created after Google auth',
+          status: 'OPEN',
+        },
+      });
+
+    expect(taskRes.status).toBe(201);
+    expect(taskRes.body.userId).toBe(res.body.user.userId);
+  });
+
+  it('logs in an existing Google user and refreshes tokens', async () => {
+    installFakeGoogleStrategy({
+      type: 'success',
+      value: fakeGoogleSuccess({
+        googleId: 'g-existing',
+        email: 'existing.google@example.com',
+        refreshToken: 'first-refresh',
+      }),
+    });
+    await request(app).get(AUTH_PATH);
+
+    installFakeGoogleStrategy({
+      type: 'success',
+      value: fakeGoogleSuccess({
+        googleId: 'g-existing',
+        email: 'existing.google@example.com',
+        accessToken: 'second-access',
+        refreshToken: 'second-refresh',
+      }),
+    });
+    const res = await request(app).get(AUTH_PATH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.email).toBe('existing.google@example.com');
+
+    const stored = await UserModel.findOne({ googleId: 'g-existing' });
+    expect(stored!.googleAccessToken).toBe('second-access');
+    expect(stored!.googleRefreshToken).toBe('second-refresh');
+    expect(await UserModel.countDocuments({ googleId: 'g-existing' })).toBe(1);
+  });
+
+  it('rejects a new Google user when refresh token is missing', async () => {
+    installFakeGoogleStrategy({
+      type: 'success',
+      value: fakeGoogleSuccess({
+        googleId: 'g-no-refresh',
+        email: 'norefresh@example.com',
+        refreshToken: '',
+      }),
+    });
+
+    const res = await request(app).get(AUTH_PATH);
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('GOOGLE_OAUTH_REFRESH_TOKEN_NOT_RECEIVED');
+    expect(await UserModel.countDocuments({ username: 'norefresh@example.com' })).toBe(0);
+  });
+
+  it('rejects Google sign-in when a verified local account already owns the email', async () => {
+    await seedTestUser({ email: 'taken@example.com' });
+    await UserModel.updateOne({ username: 'taken@example.com' }, { $set: { verified: true } });
+
+    installFakeGoogleStrategy({
+      type: 'success',
+      value: fakeGoogleSuccess({
+        googleId: 'g-taken',
+        email: 'taken@example.com',
+      }),
+    });
+
+    const res = await request(app).get(AUTH_PATH);
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('GOOGLE_OAUTH_EMAIL_ALREADY_IN_USE');
+  });
+
+  it('returns authorization failed when the Google strategy errors', async () => {
+    installFakeGoogleStrategy({
+      type: 'error',
+      error: new Error('invalid grant'),
+    });
+
+    const res = await request(app).get(AUTH_PATH);
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('GOOGLE_OAUTH_AUTHORIZATION_FAILED');
+  });
+});

--- a/backend/test/integration/integrations/slack-event-received.int.spec.ts
+++ b/backend/test/integration/integrations/slack-event-received.int.spec.ts
@@ -1,0 +1,132 @@
+import { Application } from 'express';
+import request from 'supertest';
+import SlackOAuthAccessModel from '../../../src/shared/infra/database/mongodb/slack-oauth-access.model.js';
+import { ESlackEventType } from '../../../src/modules/integrations/slack/enums/slack-event.enum.js';
+import { buildTestApp } from '../_setup/build-test-app.js';
+import { clearDatabase, startInMemoryMongo, stopInMemoryMongo } from '../_setup/mongo-memory.js';
+import { slackSignatureForBody } from '../_setup/slack.helper.js';
+
+const EVENT_PATH = '/api/integrations/slack/event-recived';
+
+describe('Integration: SlackEventReceived (Controller -> UseCase -> Repo -> MongoDB)', () => {
+  let app: Application;
+
+  beforeAll(async () => {
+    await startInMemoryMongo();
+    app = buildTestApp().app;
+  }, 30_000);
+
+  afterAll(async () => {
+    await stopInMemoryMongo();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+  });
+
+  it('answers Slack url_verification with the challenge string', async () => {
+    const res = await request(app)
+      .post(EVENT_PATH)
+      .send({ type: 'url_verification', challenge: 'challenge-token-123' });
+
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('challenge-token-123');
+  });
+
+  it('rejects events with a bad signature', async () => {
+    const body = appUninstalledBody('T-BAD-SIG');
+    const res = await request(app)
+      .post(EVENT_PATH)
+      .set('x-slack-request-timestamp', '1700000000')
+      .set('x-slack-signature', 'v0=deadbeef')
+      .send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.text).toContain('Verifying requests from Slack failed');
+  });
+
+  it('rejects events without Slack signature headers', async () => {
+    const res = await request(app).post(EVENT_PATH).send(appUninstalledBody('T-NO-HEADERS'));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('deletes Slack OAuth access on app_uninstalled', async () => {
+    await seedOAuthAccess('T-UNINSTALL');
+
+    const body = appUninstalledBody('T-UNINSTALL');
+    const res = await signedPost(app, body);
+
+    expect(res.status).toBe(200);
+    expect(await SlackOAuthAccessModel.countDocuments({ teamId: 'T-UNINSTALL' })).toBe(0);
+  });
+
+  it('handles duplicate app_uninstalled deliveries idempotently', async () => {
+    await seedOAuthAccess('T-DUP');
+    const body = appUninstalledBody('T-DUP');
+
+    const first = await signedPost(app, body);
+    const second = await signedPost(app, body);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(await SlackOAuthAccessModel.countDocuments({ teamId: 'T-DUP' })).toBe(0);
+  });
+
+  it('returns 400 for an unsupported Slack event type', async () => {
+    const body = {
+      team_id: 'T-UNSUPPORTED',
+      event: { type: 'message' },
+    };
+
+    const res = await signedPost(app, body);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('name');
+    expect(res.body.message).toContain('Is Not Supported');
+  });
+
+  it('acknowledges app_home_opened without mutating OAuth access', async () => {
+    await seedOAuthAccess('T-HOME');
+    const body = {
+      team_id: 'T-HOME',
+      event: {
+        type: ESlackEventType.AppHomeOpened,
+        user: 'U-HOME',
+        event_ts: 1700000000.123,
+      },
+    };
+
+    const res = await signedPost(app, body);
+
+    expect(res.status).toBe(200);
+    expect(await SlackOAuthAccessModel.countDocuments({ teamId: 'T-HOME' })).toBe(1);
+  });
+});
+
+async function seedOAuthAccess(teamId: string): Promise<void> {
+  await SlackOAuthAccessModel.create({
+    _id: `oauth-${teamId}`,
+    userId: `user-${teamId}`,
+    accessToken: 'xoxb-test-token',
+    authedUserId: 'U-AUTHED',
+    slackBotUserId: 'B-BOT',
+    teamId,
+  });
+}
+
+function appUninstalledBody(teamId: string) {
+  return {
+    team_id: teamId,
+    event: { type: ESlackEventType.AppUninstalled },
+  };
+}
+
+async function signedPost(app: Application, body: object) {
+  const timestamp = '1700000000';
+  return request(app)
+    .post(EVENT_PATH)
+    .set('x-slack-request-timestamp', timestamp)
+    .set('x-slack-signature', slackSignatureForBody(body, timestamp))
+    .send(body);
+}

--- a/backend/test/setup-env.ts
+++ b/backend/test/setup-env.ts
@@ -13,3 +13,4 @@ process.env.GOOGLE_OAUTH_CALLBACK = 'http://localhost/callback';
 process.env.SENDGRID_API_KEY = 'SG.test-sendgrid-api-key';
 process.env.MAILGUN_API_KEY = 'test-mailgun-api-key';
 process.env.OPEN_AI_API_KEY = 'test-openai-api-key';
+process.env.SLACK_SIGNING_SECRET = 'test-slack-signing-secret';

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -1,0 +1,89 @@
+# Lightweight stack for API smoke: real Mongo + HTTPS backend (no frontend/nginx).
+# Usage: see scripts/smoke/README.md
+
+services:
+  db:
+    image: kirushakov/braias:db
+    build: ./db
+    container_name: ba-smoke-db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: smoke
+      MONGO_INITDB_ROOT_PASSWORD: smoke-password
+      MONGO_INITDB_DATABASE: ba
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'mongosh',
+          '--quiet',
+          '-u',
+          'smoke',
+          '-p',
+          'smoke-password',
+          '--authenticationDatabase',
+          'admin',
+          '--eval',
+          "db.adminCommand('ping').ok",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  backend:
+    image: kirushakov/braias:backend
+    build:
+      context: .
+      dockerfile: ./backend/Dockerfile
+    container_name: ba-smoke-backend
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - '3443:3443'
+    volumes:
+      - ./scripts/smoke/certs:/app/backend/ssl:ro
+      - smoke_files:/app/backend/files
+    entrypoint:
+      - sh
+      - -c
+      - mkdir -p /app/backend/files/tmp /app/backend/files/uploads /tmp/ssl && chown -R node:node /app/backend/files && cp /app/backend/ssl/server.crt /app/backend/ssl/server.key /tmp/ssl/ && chmod 644 /tmp/ssl/server.crt /tmp/ssl/server.key && chown node:node /tmp/ssl/server.crt /tmp/ssl/server.key && exec gosu node npm run dev
+    environment:
+      NODE_ENV: development
+      PORT: 3443
+      DB_PORT: 27017
+      DB_CONTAINER: db
+      DB_USER: smoke
+      DB_PASSWORD: smoke-password
+      CRT_PATH: /tmp/ssl/server.crt
+      KEY_PATH: /tmp/ssl/server.key
+      FILES_UPLOAD_PATH: /app/backend/files
+      SESSION_SECRET: smoke-session-secret
+      JWT_SECRET: smoke-jwt-secret-min-32-chars-long!!
+      AUTHENTICATION_STRATEGY: JWT
+      EMAIL_DOMAIN: example.com
+      HOST: localhost
+      SENDGRID_API_KEY: SG.smoke
+      MAILGUN_API_KEY: smoke-mailgun
+      MAIL_API: sendgrid
+      SLACK_CLIENT_ID: smoke
+      SLACK_CLIENT_SECRET: smoke
+      SLACK_SIGNING_SECRET: smoke-slack-signing-secret
+      GOOGLE_CLIENT_ID: smoke-google-client-id
+      GOOGLE_CLIENT_SECRET: smoke-google-client-secret
+      GOOGLE_OAUTH_CALLBACK: http://localhost/callback
+      OPEN_AI_API_KEY: smoke-openai-key
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "process.exit(require('https').get('https://127.0.0.1:3443/',{rejectUnauthorized:false},r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))||1)",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 40s
+
+volumes:
+  smoke_files:

--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -1,0 +1,41 @@
+# Compose smoke
+
+API-level smoke against a real Docker stack (`db` + HTTPS `backend`). No frontend, no nginx, no real Slack/Drive/OpenAI.
+
+## What it checks
+
+1. `POST /api/auth/signup`
+2. Mark user `verified` in Mongo (email sending is unused in production)
+3. `POST /api/auth/login` → JWT cookie
+4. `POST /api/sync/task` → document in `tasks`
+5. Two `clientId`s both receive the task via `GET /api/sync/changes`
+
+## Run locally
+
+Docker Desktop (or Engine) must be running.
+
+```bash
+node scripts/smoke/run.mjs
+```
+
+Leave the stack up after a pass:
+
+```bash
+# PowerShell
+$env:SMOKE_KEEP_UP='1'; node scripts/smoke/run.mjs
+```
+
+Re-run only the HTTP checks against an already-up stack:
+
+```bash
+node scripts/smoke/http-smoke.mjs
+```
+
+## CI
+
+`.github/workflows/compose-smoke.yml` runs on a nightly schedule and `workflow_dispatch`. It is intentionally not on every PR — image builds are slow.
+
+## Notes
+
+- Self-signed certs are generated into `scripts/smoke/certs/` (gitignored) via an `alpine/openssl` container.
+Images are cached after the first run. A leftover `db` on host port 27017 is ignored: smoke Mongo is not published to the host.

--- a/scripts/smoke/http-smoke.mjs
+++ b/scripts/smoke/http-smoke.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Compose smoke: signup → verify in Mongo → login → create task → task in Mongo,
+ * then two sync clientIds both see the new task via GetChanges.
+ *
+ * Expects docker compose smoke stack already up (see run.mjs / README).
+ */
+import https from 'https';
+import { execFileSync } from 'child_process';
+
+const BASE_URL = process.env.SMOKE_BASE_URL ?? 'https://127.0.0.1:3443';
+const COMPOSE_FILE = process.env.SMOKE_COMPOSE_FILE ?? 'docker-compose.smoke.yml';
+const COMPOSE_PROJECT = process.env.SMOKE_COMPOSE_PROJECT ?? 'ba-smoke';
+const EMAIL = `smoke-${Date.now()}@example.com`;
+const PASSWORD = 'password123';
+const TASK_ID = `smoke-task-${Date.now()}`;
+const TASK_TITLE = 'Compose smoke task';
+
+const agent = new https.Agent({ rejectUnauthorized: false });
+
+function log(step, detail = '') {
+  console.log(`[smoke] ${step}${detail ? `: ${detail}` : ''}`);
+}
+
+function fail(message) {
+  console.error(`[smoke] FAIL: ${message}`);
+  process.exit(1);
+}
+
+async function request(method, path, { body, cookie } = {}) {
+  const url = new URL(path, BASE_URL);
+  const headers = { Accept: 'application/json' };
+  let payload;
+  if (body !== undefined) {
+    payload = JSON.stringify(body);
+    headers['Content-Type'] = 'application/json';
+    headers['Content-Length'] = Buffer.byteLength(payload);
+  }
+  if (cookie) {
+    headers.Cookie = cookie;
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      url,
+      { method, headers, agent },
+      res => {
+        const chunks = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          let json;
+          try {
+            json = raw ? JSON.parse(raw) : undefined;
+          } catch {
+            json = undefined;
+          }
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: json,
+            text: raw,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+function jwtCookieFromSetCookie(setCookie) {
+  const list = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : [];
+  const jwt = list.find(c => c.startsWith('jwt='));
+  if (!jwt) {
+    fail(`No jwt Set-Cookie in: ${JSON.stringify(list)}`);
+  }
+  return jwt.split(';')[0];
+}
+
+function mongosh(evalJs) {
+  return execFileSync(
+    'docker',
+    [
+      'compose',
+      '-p',
+      COMPOSE_PROJECT,
+      '-f',
+      COMPOSE_FILE,
+      'exec',
+      '-T',
+      'db',
+      'mongosh',
+      '--quiet',
+      '-u',
+      'smoke',
+      '-p',
+      'smoke-password',
+      '--authenticationDatabase',
+      'admin',
+      'ba',
+      '--eval',
+      evalJs,
+    ],
+    { encoding: 'utf8' },
+  ).trim();
+}
+
+async function waitForBackend(timeoutMs = 180_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await request('GET', '/');
+      if (res.status === 200) {
+        log('backend up', res.body?.message ?? res.text);
+        return;
+      }
+    } catch {
+      // still booting
+    }
+    await new Promise(r => setTimeout(r, 2000));
+  }
+  fail(`backend not reachable at ${BASE_URL} within ${timeoutMs}ms`);
+}
+
+async function main() {
+  await waitForBackend();
+
+  log('signup', EMAIL);
+  const signup = await request('POST', '/api/auth/signup', {
+    body: {
+      email: EMAIL,
+      firstName: 'Smoke',
+      lastName: 'User',
+      password: PASSWORD,
+    },
+  });
+  if (signup.status !== 200 && signup.status !== 201) {
+    fail(`signup ${signup.status} ${signup.text}`);
+  }
+
+  log('mark user verified in Mongo');
+  mongosh(
+    `db.users.updateOne({ username: '${EMAIL}' }, { $set: { verified: true } })`,
+  );
+
+  log('login');
+  const login = await request('POST', '/api/auth/login', {
+    body: { username: EMAIL, password: PASSWORD },
+  });
+  if (login.status !== 200) {
+    fail(`login ${login.status} ${login.text}`);
+  }
+  const jwtCookie = jwtCookieFromSetCookie(login.headers['set-cookie']);
+  const userId = login.body?.user?.userId;
+  if (!userId) {
+    fail(`login response missing userId: ${login.text}`);
+  }
+
+  log('allocate two sync clientIds');
+  const clientARes = await request('GET', '/api/sync/release-client-id', {
+    cookie: jwtCookie,
+  });
+  const clientBRes = await request('GET', '/api/sync/release-client-id', {
+    cookie: jwtCookie,
+  });
+  if (clientARes.status !== 200 || clientBRes.status !== 200) {
+    fail(`release-client-id failed: ${clientARes.status}/${clientBRes.status}`);
+  }
+  const clientA = clientARes.body.clientId;
+  const clientB = clientBRes.body.clientId;
+
+  log('create task', TASK_ID);
+  const create = await request('POST', '/api/sync/task', {
+    cookie: jwtCookie,
+    body: {
+      changeableObjectDto: {
+        id: TASK_ID,
+        type: 'TASK',
+        title: TASK_TITLE,
+        status: 'OPEN',
+      },
+    },
+  });
+  if (create.status !== 201) {
+    fail(`create task ${create.status} ${create.text}`);
+  }
+  if (create.body?.userId !== userId) {
+    fail(`task userId mismatch: ${JSON.stringify(create.body)}`);
+  }
+
+  log('assert task document in Mongo');
+  const taskCount = mongosh(`db.tasks.countDocuments({ _id: '${TASK_ID}' })`);
+  if (taskCount !== '1') {
+    fail(`expected 1 task in Mongo, got ${taskCount}`);
+  }
+
+  const changesA = await request(
+    'GET',
+    `/api/sync/changes?clientId=${encodeURIComponent(clientA)}`,
+    { cookie: jwtCookie },
+  );
+  const changesB = await request(
+    'GET',
+    `/api/sync/changes?clientId=${encodeURIComponent(clientB)}`,
+    { cookie: jwtCookie },
+  );
+  if (changesA.status !== 200 || changesB.status !== 200) {
+    fail(`get-changes failed: ${changesA.status}/${changesB.status}`);
+  }
+
+  const aHasTask = (changesA.body?.changes ?? []).some(
+    c => c?.object?.id === TASK_ID || c?.object?.title === TASK_TITLE,
+  );
+  const bHasTask = (changesB.body?.changes ?? []).some(
+    c => c?.object?.id === TASK_ID || c?.object?.title === TASK_TITLE,
+  );
+  if (!aHasTask || !bHasTask) {
+    fail(
+      `both clients should see the task; A=${JSON.stringify(changesA.body)} B=${JSON.stringify(changesB.body)}`,
+    );
+  }
+
+  log('OK', 'signup → task in Mongo → two clientIds see GetChanges');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/smoke/run.mjs
+++ b/scripts/smoke/run.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Boots docker-compose.smoke.yml, runs http-smoke.mjs, then tears down.
+ * Cross-platform (Windows / Linux / macOS) via docker + node.
+ */
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const COMPOSE_FILE = 'docker-compose.smoke.yml';
+const COMPOSE_PROJECT = 'ba-smoke';
+const CERT_DIR = path.join(__dirname, 'certs');
+const KEEP_UP = process.env.SMOKE_KEEP_UP === '1';
+
+function run(cmd, args, opts = {}) {
+  console.log(`[smoke-run] ${cmd} ${args.join(' ')}`);
+  const result = spawnSync(cmd, args, {
+    cwd: ROOT,
+    stdio: 'inherit',
+    shell: false,
+    ...opts,
+  });
+  return result.status ?? 1;
+}
+
+function ensureCerts() {
+  fs.mkdirSync(CERT_DIR, { recursive: true });
+  const crt = path.join(CERT_DIR, 'server.crt');
+  const key = path.join(CERT_DIR, 'server.key');
+  if (fs.existsSync(crt) && fs.existsSync(key)) {
+    console.log('[smoke-run] reusing existing smoke TLS certs');
+    return;
+  }
+
+  console.log('[smoke-run] generating self-signed TLS certs via openssl container');
+  const status = run('docker', [
+    'run',
+    '--rm',
+    '-v',
+    `${CERT_DIR}:/certs`,
+    'alpine/openssl',
+    'req',
+    '-x509',
+    '-nodes',
+    '-newkey',
+    'rsa:2048',
+    '-keyout',
+    '/certs/server.key',
+    '-out',
+    '/certs/server.crt',
+    '-days',
+    '1',
+    '-subj',
+    '/CN=localhost',
+  ]);
+  if (status !== 0) {
+    process.exit(status);
+  }
+}
+
+function compose(...args) {
+  return run('docker', ['compose', '-p', COMPOSE_PROJECT, '-f', COMPOSE_FILE, ...args]);
+}
+
+ensureCerts();
+
+let smokeStatus = 1;
+try {
+  const upStatus = compose('up', '-d', '--build');
+  if (upStatus !== 0) {
+    process.exit(upStatus);
+  }
+
+  smokeStatus = run(process.execPath, [path.join(__dirname, 'http-smoke.mjs')], {
+    env: {
+      ...process.env,
+      SMOKE_COMPOSE_FILE: COMPOSE_FILE,
+      SMOKE_COMPOSE_PROJECT: COMPOSE_PROJECT,
+      SMOKE_BASE_URL: 'https://127.0.0.1:3443',
+    },
+  });
+
+  if (smokeStatus === 0) {
+    console.log('[smoke-run] PASSED');
+  }
+} finally {
+  if (!KEEP_UP) {
+    compose('down', '-v');
+  } else {
+    console.log('[smoke-run] SMOKE_KEEP_UP=1 — leaving stack running');
+  }
+}
+
+process.exit(smokeStatus);


### PR DESCRIPTION
## Summary
- Slack webhook HMAC: missing/invalid signature returns 400; valid signed events reach the use-case. Fixes a double `next()` in the Slack verification middleware.
- Speech-to-text integration with OpenAI mocked: 401, 200 transcript, unsupported MIME, and 502 on provider failure.
- Docker compose smoke (nightly, not every PR): signup → verify in Mongo → login JWT → two `clientId`s POST a task → both GetChanges see it.
- Google OAuth callback via Passport FakeStrategy (no real Google): new user + JWT + create task, token refresh, missing refresh, verified-email conflict, strategy error.

## Test plan
- [ ] `backend` Jest: Slack event-received, speech-to-text, Google FakeStrategy specs pass
- [ ] Compose smoke: `scripts/smoke/README.md` local run succeeds (or wait for nightly `compose-smoke` workflow)
- [ ] Confirm `scripts/smoke/certs/` is not in the PR

Made with [Cursor](https://cursor.com)