### PR TITLE
test: align Playwright mocks with real sync response bodies

### DIFF
--- a/backend/test/integration/sync/task-delete.int.spec.ts
+++ b/backend/test/integration/sync/task-delete.int.spec.ts
@@ -39,6 +39,7 @@ describe('Integration: DeleteTask (Controller -> UseCase -> Repo -> MongoDB)', (
     const res = await authenticatedRequest(app, jwtCookie).delete(`/api/sync/task/${created.id}`);
 
     expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
     expect(await models.TaskModel.findById(created.id).lean()).toBeNull();
 
     const action = await models.ActionModel.findOne({

--- a/backend/test/integration/sync/task-update.int.spec.ts
+++ b/backend/test/integration/sync/task-update.int.spec.ts
@@ -55,6 +55,7 @@ describe('Integration: UpdateTask (Controller -> UseCase -> Repo -> MongoDB)', (
       .set('Accept', 'application/json');
 
     expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
 
     const persisted = await models.TaskModel.findById(created.id).lean();
     expect(persisted).toMatchObject({

--- a/contracts/src/contracts/send-change.contract.ts
+++ b/contracts/src/contracts/send-change.contract.ts
@@ -6,7 +6,7 @@ import { ChangeableObjectDTO } from "../dto";
  * 
  * Examples:
  * - POST /api/sync/task { changeableObjectDto: TaskDTO } → Returns TaskDTO
- * - PATCH /api/sync/task { changeableObjectDto: TaskDTO } → Returns TaskDTO
+ * - PATCH /api/sync/task { changeableObjectDto: TaskDTO } → Returns void
  * - DELETE /api/sync/task/:id → Returns void
  */
 export namespace SendChangeContract {
@@ -21,10 +21,10 @@ export namespace SendChangeContract {
   /**
    * Response for sending a change to the server
    * 
-   * Returns the created/updated entity for POST/PATCH requests.
+   * Returns the created entity for POST requests.
    * This confirms what the server actually saved (server is source of truth).
    * 
-   * For DELETE requests, returns void.
+   * PATCH and DELETE answer 200 with no payload.
    */
   export type Response<T extends ChangeableObjectDTO = ChangeableObjectDTO> = T | void;
 }

--- a/frontend/e2e/utils/api-mocks.util.ts
+++ b/frontend/e2e/utils/api-mocks.util.ts
@@ -36,6 +36,10 @@ function parseSendChangeTask(postData: string | null): TaskDTO | null {
 
 /**
  * Mocks backend API routes so E2E specs run without a live server.
+ *
+ * Statuses and response bodies must mirror the real backend, which is pinned by the
+ * integration specs in `backend/test/integration/`. Only `POST /api/sync/task` returns
+ * an entity; update and delete answer 200 with no payload.
  */
 export async function setupApiMocks(
   page: Page,
@@ -71,8 +75,7 @@ export async function setupApiMocks(
     }
 
     if (url.includes('/api/sync/task') && method === 'PATCH') {
-      const task = parseSendChangeTask(request.postData());
-      await route.fulfill(json(200, task ?? {}));
+      await route.fulfill(json(200, {}));
       return;
     }
 
@@ -83,7 +86,7 @@ export async function setupApiMocks(
 
     if (url.includes('/api/files/image') && method === 'POST') {
       const body: UploadImageContract.Response = { imageId: 'mock-uploaded-image-id' };
-      await route.fulfill(json(201, body));
+      await route.fulfill(json(200, body));
       return;
     }
 


### PR DESCRIPTION
## Summary
- Integration specs for task update/delete now assert an empty `200` body, matching what the backend actually returns via `this.ok(res)`.
- Playwright `api-mocks` no longer invent a `TaskDTO` on PATCH or `201` on image upload; both mirror the live API (`200` + empty body / `{ imageId }`).
- `SendChangeContract` docs corrected: only POST returns an entity; PATCH and DELETE answer with no payload.

## Test plan
- [ ] `cd backend; npm test -- task-update.int.spec.ts task-delete.int.spec.ts`
- [ ] `cd frontend; npm run e2e`
- [ ] Confirm mocks stay in sync with any future change to update/delete/upload response shapes

Made with [Cursor](https://cursor.com)