### PR TITLE
test: narrow TaskDTO enums and snapshot public API shape

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -37,6 +37,10 @@ jobs:
       working-directory: ./backend
       run: npm ci
 
+    - name: Run contracts tests
+      working-directory: ./contracts
+      run: npm test
+
     - name: Run linter
       working-directory: ./backend
       run: npm run lint

--- a/backend/src/shared/mappers/task.mapper.ts
+++ b/backend/src/shared/mappers/task.mapper.ts
@@ -1,5 +1,5 @@
 import { Task, TaskPresitant } from '../domain/models/task.js';
-import { TaskDTO } from '@brainassistant/contracts';
+import { TaskDTO, ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import { UniqueEntityID } from '../domain/UniqueEntityID.js';
 import { DomainError } from '../core/domain-error.js';
 
@@ -38,9 +38,9 @@ export class TaskMapper {
     return {
       id: task.id.toString(),
       userId: task.userId,
-      type: task.type,
+      type: task.type as ETaskType,
       title: task.title,
-      status: task.status,
+      status: task.status as ETaskStatus,
       imageId: task.imageId,
       createdAt: task.createdAt.toISOString(),
       modifiedAt: task.modifiedAt.toISOString(),

--- a/backend/test/integration/_setup/harness.smoke.spec.ts
+++ b/backend/test/integration/_setup/harness.smoke.spec.ts
@@ -1,5 +1,6 @@
 import request from 'supertest';
 import { Application } from 'express';
+import { ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import { startInMemoryMongo, stopInMemoryMongo, clearDatabase } from './mongo-memory.js';
 import { buildTestApp } from './build-test-app.js';
 import { authenticatedRequest, seedTestUser } from './auth.helper.js';
@@ -24,9 +25,9 @@ describe('Integration: test harness (createApp + JWT)', () => {
     const res = await request(app).post('/api/sync/task').send({
       changeableObjectDto: {
         id: 'task-unauth',
-        type: 'TASK',
+        type: ETaskType.Basic,
         title: 'Should not be created',
-        status: 'OPEN',
+        status: ETaskStatus.Todo,
       },
     });
 
@@ -45,9 +46,9 @@ describe('Integration: test harness (createApp + JWT)', () => {
       .send({
         changeableObjectDto: {
           id: 'task-smoke-1',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Harness smoke task',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
         },
       })
       .set('Accept', 'application/json');

--- a/backend/test/integration/_setup/sync.helper.ts
+++ b/backend/test/integration/_setup/sync.helper.ts
@@ -1,12 +1,12 @@
 import { Application } from 'express';
-import { TaskDTO } from '@brainassistant/contracts';
+import { TaskDTO, ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import { authenticatedRequest } from './auth.helper.js';
 
 export type TaskSeed = {
   id: string;
-  type?: string;
+  type?: ETaskType;
   title?: string;
-  status?: string;
+  status?: ETaskStatus;
   imageId?: string;
 };
 
@@ -29,9 +29,9 @@ export async function createTaskViaApi(
 ): Promise<TaskDTO> {
   const dto = {
     id: seed.id,
-    type: seed.type ?? 'TASK',
+    type: seed.type ?? ETaskType.Basic,
     title: seed.title ?? 'Integration Test Task',
-    status: seed.status ?? 'OPEN',
+    status: seed.status ?? ETaskStatus.Todo,
     ...(seed.imageId !== undefined ? { imageId: seed.imageId } : {}),
   };
 

--- a/backend/test/integration/auth/google-auth.int.spec.ts
+++ b/backend/test/integration/auth/google-auth.int.spec.ts
@@ -1,5 +1,6 @@
 import { Application } from 'express';
 import request from 'supertest';
+import { ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import UserModel from '../../../src/shared/infra/database/mongodb/user.model.js';
 import {
   authenticatedRequest,
@@ -62,9 +63,9 @@ describe('Integration: GoogleAuth (Controller -> UseCase -> Repo -> MongoDB)', (
       .send({
         changeableObjectDto: {
           id: 'task-from-google',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Created after Google auth',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
         },
       });
 

--- a/backend/test/integration/auth/login.int.spec.ts
+++ b/backend/test/integration/auth/login.int.spec.ts
@@ -1,6 +1,6 @@
 import { Application } from 'express';
 import request from 'supertest';
-import { TaskDTO } from '@brainassistant/contracts';
+import { TaskDTO, ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import UserModel from '../../../src/shared/infra/database/mongodb/user.model.js';
 import {
   authenticatedRequest,
@@ -82,9 +82,9 @@ describe('Integration: Login (Controller -> UseCase -> Repo -> MongoDB)', () => 
       .send({
         changeableObjectDto: {
           id: 'task-from-login',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Created after login',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
         },
       })
       .set('Accept', 'application/json');

--- a/backend/test/integration/sync/task-create.int.spec.ts
+++ b/backend/test/integration/sync/task-create.int.spec.ts
@@ -1,6 +1,6 @@
 import { Application } from 'express';
 import request from 'supertest';
-import { TaskDTO } from '@brainassistant/contracts';
+import { TaskDTO, ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import { models } from '../../../src/shared/infra/database/mongodb/index.js';
 import { authenticatedRequest, seedTestUser } from '../_setup/auth.helper.js';
 import { buildTestApp } from '../_setup/build-test-app.js';
@@ -28,9 +28,9 @@ describe('Integration: CreateTask (Controller -> UseCase -> Repo -> MongoDB)', (
       .send({
         changeableObjectDto: {
           id: 'task-unauth',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Should not be created',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
         },
       });
 
@@ -42,9 +42,9 @@ describe('Integration: CreateTask (Controller -> UseCase -> Repo -> MongoDB)', (
 
     const dto = {
       id: 'task-123',
-      type: 'TASK',
+      type: ETaskType.Basic,
       title: 'Integration Test Task',
-      status: 'OPEN',
+      status: ETaskStatus.Todo,
       imageId: 'image-456',
     };
 
@@ -78,9 +78,9 @@ describe('Integration: CreateTask (Controller -> UseCase -> Repo -> MongoDB)', (
 
     const badDto = {
       id: 'task-err-1',
-      type: 'TASK',
+      type: ETaskType.Basic,
       title: '',
-      status: 'OPEN',
+      status: ETaskStatus.Todo,
     };
 
     const res = await authenticatedRequest(app, jwtCookie)

--- a/backend/test/integration/sync/task-update.int.spec.ts
+++ b/backend/test/integration/sync/task-update.int.spec.ts
@@ -1,5 +1,6 @@
 import { Application } from 'express';
 import request from 'supertest';
+import { ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import { models } from '../../../src/shared/infra/database/mongodb/index.js';
 import { authenticatedRequest, seedTestUser } from '../_setup/auth.helper.js';
 import { buildTestApp } from '../_setup/build-test-app.js';
@@ -28,9 +29,9 @@ describe('Integration: UpdateTask (Controller -> UseCase -> Repo -> MongoDB)', (
       .send({
         changeableObjectDto: {
           id: 'task-unauth',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Should not update',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
         },
       });
 
@@ -74,9 +75,9 @@ describe('Integration: UpdateTask (Controller -> UseCase -> Repo -> MongoDB)', (
       .send({
         changeableObjectDto: {
           id: 'task-missing',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Missing task title',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
         },
       })
       .set('Accept', 'application/json');

--- a/backend/test/unit/domain/task.spec.ts
+++ b/backend/test/unit/domain/task.spec.ts
@@ -1,10 +1,11 @@
 import { ETaskError, Task } from '../../../src/shared/domain/models/task.js';
 import { UniqueEntityID } from '../../../src/shared/domain/UniqueEntityID.js';
+import { ETaskStatus, ETaskType } from '@brainassistant/contracts';
 
 const baseTaskProps = {
   userId: 'user-1',
-  type: 'TASK',
-  status: 'OPEN',
+  type: ETaskType.Basic,
+  status: ETaskStatus.Todo,
 } as const;
 
 describe('Task', () => {

--- a/backend/test/unit/mappers/task.mapper.spec.ts
+++ b/backend/test/unit/mappers/task.mapper.spec.ts
@@ -1,6 +1,7 @@
 import { Task, TaskPresitant } from '../../../src/shared/domain/models/task.js';
 import { UniqueEntityID } from '../../../src/shared/domain/UniqueEntityID.js';
 import { TaskMapper } from '../../../src/shared/mappers/task.mapper.js';
+import { ETaskStatus, ETaskType } from '@brainassistant/contracts';
 
 describe('TaskMapper', () => {
   beforeEach(() => {
@@ -17,9 +18,9 @@ describe('TaskMapper', () => {
       const task = Task.create(
         {
           userId: 'user-1',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Valid task title',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
         },
         new UniqueEntityID('task-123'),
       ).getValue();
@@ -40,9 +41,9 @@ describe('TaskMapper', () => {
       const raw: TaskPresitant = {
         _id: 'task-1',
         userId: 'user-1',
-        type: 'TASK',
+        type: ETaskType.Basic,
         title: 'Persisted task title',
-        status: 'OPEN',
+        status: ETaskStatus.Todo,
         createdAt,
         modifiedAt,
       };
@@ -59,9 +60,9 @@ describe('TaskMapper', () => {
       const task = Task.create(
         {
           userId: 'user-1',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Valid task title',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
         },
         new UniqueEntityID('task-123'),
       ).getValue();
@@ -81,9 +82,9 @@ describe('TaskMapper', () => {
       const original = Task.create(
         {
           userId: 'user-1',
-          type: 'TASK',
+          type: ETaskType.Basic,
           title: 'Valid task title',
-          status: 'OPEN',
+          status: ETaskStatus.Todo,
           imageId: 'image-1',
         },
         new UniqueEntityID('task-123'),

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
+    "test": "npm run build && node --test test/public-api.shape.test.cjs",
     "watch": "tsc --watch",
     "clean": "rm -rf dist"
   },

--- a/contracts/src/dto/task.dto.ts
+++ b/contracts/src/dto/task.dto.ts
@@ -1,3 +1,6 @@
+import { ETaskStatus } from '../enums/task-status.enum';
+import { ETaskType } from '../enums/task-type.enum';
+
 /**
  * Task Data Transfer Object
  * Shared contract between frontend and backend for task data
@@ -5,11 +8,10 @@
 export interface TaskDTO {
   id: string;
   userId: string;
-  type: string;
+  type: ETaskType;
   title: string;
-  status: string;
+  status: ETaskStatus;
   imageId?: string;
   createdAt: string;
   modifiedAt: string;
 }
-

--- a/contracts/src/enums/index.ts
+++ b/contracts/src/enums/index.ts
@@ -5,4 +5,6 @@
 
 export { EChangedEntity } from './changed-entity.enum';
 export { EChangeAction } from './change-action.enum';
+export { ETaskStatus } from './task-status.enum';
+export { ETaskType } from './task-type.enum';
 

--- a/contracts/src/enums/task-status.enum.ts
+++ b/contracts/src/enums/task-status.enum.ts
@@ -1,0 +1,9 @@
+/**
+ * Wire values for TaskDTO.status. Cached PWAs send these strings;
+ * renaming or removing a member is a breaking change.
+ */
+export enum ETaskStatus {
+  Todo = 'TASK_STATUS_TODO',
+  Done = 'TASK_STATUS_DONE',
+  Cancel = 'TASK_STATUS_CANCEL',
+}

--- a/contracts/src/enums/task-type.enum.ts
+++ b/contracts/src/enums/task-type.enum.ts
@@ -1,0 +1,7 @@
+/**
+ * Wire values for TaskDTO.type. Cached PWAs send these strings;
+ * renaming or removing a member is a breaking change.
+ */
+export enum ETaskType {
+  Basic = 'TASK_TYPE_BASIC',
+}

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -24,7 +24,7 @@ export type {
 } from './dto';
 
 // Enums
-export { EChangedEntity, EChangeAction } from './enums';
+export { EChangedEntity, EChangeAction, ETaskStatus, ETaskType } from './enums';
 
 // Contracts
 export { UploadImageContract, SendChangeContract, GetChangesContract } from './contracts';

--- a/contracts/src/public-api.shape.ts
+++ b/contracts/src/public-api.shape.ts
@@ -1,0 +1,167 @@
+/**
+ * Serializable description of the public HTTP types.
+ *
+ * Cached PWA clients are compiled against a previous version of this package.
+ * Removing a DTO field, renaming an enum member, or dropping a wire value is a
+ * breaking change: `tsc` fails here first, then `npm test` fails against
+ * `test/public-api.shape.json` until the snapshot is updated on purpose.
+ */
+
+import type {
+  ApiErrorDto,
+  ApiSuccessDto,
+  ChangeDTO,
+  DeletedObjectDTO,
+  IChangeableObjectDTO,
+  LoginRequestDTO,
+  LoginResponseDTO,
+  SignUpRequestDTO,
+  SignUpResponseDTO,
+  TagDTO,
+  TaskDTO,
+  UserDto,
+  VerifyEmailResponseDTO,
+} from './dto';
+import { GetChangesContract, SendChangeContract, UploadImageContract } from './contracts';
+import { EChangeAction, EChangedEntity, ETaskStatus, ETaskType } from './enums';
+
+type ExactKeys<T, K extends readonly (keyof T)[]> = Exclude<keyof T, K[number]> extends never
+  ? Exclude<K[number], keyof T> extends never
+    ? true
+    : never
+  : never;
+
+const TASK_DTO_KEYS = [
+  'id',
+  'userId',
+  'type',
+  'title',
+  'status',
+  'imageId',
+  'createdAt',
+  'modifiedAt',
+] as const satisfies readonly (keyof TaskDTO)[];
+const _taskDto: ExactKeys<TaskDTO, typeof TASK_DTO_KEYS> = true;
+
+const USER_DTO_KEYS = ['firstName', 'lastName', 'email', 'userId'] as const satisfies readonly (keyof UserDto)[];
+const _userDto: ExactKeys<UserDto, typeof USER_DTO_KEYS> = true;
+
+const TAG_DTO_KEYS = [
+  'id',
+  'userId',
+  'isCategory',
+  'name',
+  'color',
+  'createdAt',
+  'modifiedAt',
+] as const satisfies readonly (keyof TagDTO)[];
+const _tagDto: ExactKeys<TagDTO, typeof TAG_DTO_KEYS> = true;
+
+const CHANGEABLE_OBJECT_KEYS = ['id', 'modifiedAt'] as const satisfies readonly (keyof IChangeableObjectDTO)[];
+const _changeable: ExactKeys<IChangeableObjectDTO, typeof CHANGEABLE_OBJECT_KEYS> = true;
+const _deleted: ExactKeys<DeletedObjectDTO, typeof CHANGEABLE_OBJECT_KEYS> = true;
+
+const CHANGE_DTO_KEYS = ['entity', 'action', 'object'] as const satisfies readonly (keyof ChangeDTO)[];
+const _changeDto: ExactKeys<ChangeDTO, typeof CHANGE_DTO_KEYS> = true;
+
+const LOGIN_REQUEST_KEYS = ['username', 'password'] as const satisfies readonly (keyof LoginRequestDTO)[];
+const _loginReq: ExactKeys<LoginRequestDTO, typeof LOGIN_REQUEST_KEYS> = true;
+
+const LOGIN_RESPONSE_KEYS = ['user', 'expireAt'] as const satisfies readonly (keyof LoginResponseDTO)[];
+const _loginRes: ExactKeys<LoginResponseDTO, typeof LOGIN_RESPONSE_KEYS> = true;
+
+const SIGNUP_REQUEST_KEYS = [
+  'email',
+  'firstName',
+  'lastName',
+  'password',
+] as const satisfies readonly (keyof SignUpRequestDTO)[];
+const _signupReq: ExactKeys<SignUpRequestDTO, typeof SIGNUP_REQUEST_KEYS> = true;
+
+const SIGNUP_RESPONSE_KEYS = ['email', 'firstName', 'lastName'] as const satisfies readonly (keyof SignUpResponseDTO)[];
+const _signupRes: ExactKeys<SignUpResponseDTO, typeof SIGNUP_RESPONSE_KEYS> = true;
+
+const VERIFY_EMAIL_KEYS = ['email', 'verified'] as const satisfies readonly (keyof VerifyEmailResponseDTO)[];
+const _verify: ExactKeys<VerifyEmailResponseDTO, typeof VERIFY_EMAIL_KEYS> = true;
+
+const API_ERROR_KEYS = ['name', 'message'] as const satisfies readonly (keyof ApiErrorDto)[];
+const _apiError: ExactKeys<ApiErrorDto, typeof API_ERROR_KEYS> = true;
+
+const API_SUCCESS_KEYS = ['data'] as const satisfies readonly (keyof ApiSuccessDto)[];
+const _apiSuccess: ExactKeys<ApiSuccessDto, typeof API_SUCCESS_KEYS> = true;
+
+const UPLOAD_REQUEST_KEYS = ['imageId', 'file'] as const satisfies readonly (keyof UploadImageContract.Request)[];
+const _uploadReq: ExactKeys<UploadImageContract.Request, typeof UPLOAD_REQUEST_KEYS> = true;
+
+const UPLOAD_RESPONSE_KEYS = ['imageId'] as const satisfies readonly (keyof UploadImageContract.Response)[];
+const _uploadRes: ExactKeys<UploadImageContract.Response, typeof UPLOAD_RESPONSE_KEYS> = true;
+
+const GET_CHANGES_REQUEST_KEYS = ['clientId'] as const satisfies readonly (keyof GetChangesContract.Request)[];
+const _getChangesReq: ExactKeys<GetChangesContract.Request, typeof GET_CHANGES_REQUEST_KEYS> = true;
+
+const GET_CHANGES_RESPONSE_KEYS = ['changes'] as const satisfies readonly (keyof GetChangesContract.Response)[];
+const _getChangesRes: ExactKeys<GetChangesContract.Response, typeof GET_CHANGES_RESPONSE_KEYS> = true;
+
+const SEND_CHANGE_REQUEST_KEYS = [
+  'changeableObjectDto',
+] as const satisfies readonly (keyof SendChangeContract.Request)[];
+const _sendChangeReq: ExactKeys<SendChangeContract.Request, typeof SEND_CHANGE_REQUEST_KEYS> = true;
+
+void _taskDto;
+void _userDto;
+void _tagDto;
+void _changeable;
+void _deleted;
+void _changeDto;
+void _loginReq;
+void _loginRes;
+void _signupReq;
+void _signupRes;
+void _verify;
+void _apiError;
+void _apiSuccess;
+void _uploadReq;
+void _uploadRes;
+void _getChangesReq;
+void _getChangesRes;
+void _sendChangeReq;
+
+export const PUBLIC_API_SHAPE = {
+  enums: {
+    ETaskType: Object.values(ETaskType),
+    ETaskStatus: Object.values(ETaskStatus),
+    EChangedEntity: Object.values(EChangedEntity),
+    EChangeAction: Object.values(EChangeAction),
+  },
+  dto: {
+    TaskDTO: {
+      keys: [...TASK_DTO_KEYS],
+      optional: ['imageId'],
+    },
+    UserDto: { keys: [...USER_DTO_KEYS], optional: [] as string[] },
+    TagDTO: { keys: [...TAG_DTO_KEYS], optional: [] as string[] },
+    IChangeableObjectDTO: { keys: [...CHANGEABLE_OBJECT_KEYS], optional: [] as string[] },
+    ChangeDTO: { keys: [...CHANGE_DTO_KEYS], optional: [] as string[] },
+    LoginRequestDTO: { keys: [...LOGIN_REQUEST_KEYS], optional: [] as string[] },
+    LoginResponseDTO: { keys: [...LOGIN_RESPONSE_KEYS], optional: ['expireAt'] },
+    SignUpRequestDTO: { keys: [...SIGNUP_REQUEST_KEYS], optional: [] as string[] },
+    SignUpResponseDTO: { keys: [...SIGNUP_RESPONSE_KEYS], optional: [] as string[] },
+    VerifyEmailResponseDTO: { keys: [...VERIFY_EMAIL_KEYS], optional: [] as string[] },
+    ApiErrorDto: { keys: [...API_ERROR_KEYS], optional: [] as string[] },
+    ApiSuccessDto: { keys: [...API_SUCCESS_KEYS], optional: [] as string[] },
+  },
+  contracts: {
+    UploadImageContract: {
+      request: [...UPLOAD_REQUEST_KEYS],
+      response: [...UPLOAD_RESPONSE_KEYS],
+    },
+    GetChangesContract: {
+      request: [...GET_CHANGES_REQUEST_KEYS],
+      response: [...GET_CHANGES_RESPONSE_KEYS],
+    },
+    SendChangeContract: {
+      request: [...SEND_CHANGE_REQUEST_KEYS],
+      response: 'entity-or-void',
+    },
+  },
+};

--- a/contracts/test/public-api.shape.json
+++ b/contracts/test/public-api.shape.json
@@ -1,0 +1,152 @@
+{
+  "enums": {
+    "ETaskType": [
+      "TASK_TYPE_BASIC"
+    ],
+    "ETaskStatus": [
+      "TASK_STATUS_TODO",
+      "TASK_STATUS_DONE",
+      "TASK_STATUS_CANCEL"
+    ],
+    "EChangedEntity": [
+      "CHANGED_ENTITY_TASK",
+      "CHANGED_ENTITY_TAG"
+    ],
+    "EChangeAction": [
+      "CHANGE_ACTION_CREATED",
+      "CHANGE_ACTION_UPDATED",
+      "CHANGE_ACTION_DELETED"
+    ]
+  },
+  "dto": {
+    "TaskDTO": {
+      "keys": [
+        "id",
+        "userId",
+        "type",
+        "title",
+        "status",
+        "imageId",
+        "createdAt",
+        "modifiedAt"
+      ],
+      "optional": [
+        "imageId"
+      ]
+    },
+    "UserDto": {
+      "keys": [
+        "firstName",
+        "lastName",
+        "email",
+        "userId"
+      ],
+      "optional": []
+    },
+    "TagDTO": {
+      "keys": [
+        "id",
+        "userId",
+        "isCategory",
+        "name",
+        "color",
+        "createdAt",
+        "modifiedAt"
+      ],
+      "optional": []
+    },
+    "IChangeableObjectDTO": {
+      "keys": [
+        "id",
+        "modifiedAt"
+      ],
+      "optional": []
+    },
+    "ChangeDTO": {
+      "keys": [
+        "entity",
+        "action",
+        "object"
+      ],
+      "optional": []
+    },
+    "LoginRequestDTO": {
+      "keys": [
+        "username",
+        "password"
+      ],
+      "optional": []
+    },
+    "LoginResponseDTO": {
+      "keys": [
+        "user",
+        "expireAt"
+      ],
+      "optional": [
+        "expireAt"
+      ]
+    },
+    "SignUpRequestDTO": {
+      "keys": [
+        "email",
+        "firstName",
+        "lastName",
+        "password"
+      ],
+      "optional": []
+    },
+    "SignUpResponseDTO": {
+      "keys": [
+        "email",
+        "firstName",
+        "lastName"
+      ],
+      "optional": []
+    },
+    "VerifyEmailResponseDTO": {
+      "keys": [
+        "email",
+        "verified"
+      ],
+      "optional": []
+    },
+    "ApiErrorDto": {
+      "keys": [
+        "name",
+        "message"
+      ],
+      "optional": []
+    },
+    "ApiSuccessDto": {
+      "keys": [
+        "data"
+      ],
+      "optional": []
+    }
+  },
+  "contracts": {
+    "UploadImageContract": {
+      "request": [
+        "imageId",
+        "file"
+      ],
+      "response": [
+        "imageId"
+      ]
+    },
+    "GetChangesContract": {
+      "request": [
+        "clientId"
+      ],
+      "response": [
+        "changes"
+      ]
+    },
+    "SendChangeContract": {
+      "request": [
+        "changeableObjectDto"
+      ],
+      "response": "entity-or-void"
+    }
+  }
+}

--- a/contracts/test/public-api.shape.test.cjs
+++ b/contracts/test/public-api.shape.test.cjs
@@ -1,0 +1,17 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { PUBLIC_API_SHAPE } = require('../dist/public-api.shape.js');
+
+test('public API shape matches the committed snapshot', () => {
+  const snapshotPath = path.join(__dirname, 'public-api.shape.json');
+  const expected = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+  assert.deepEqual(
+    PUBLIC_API_SHAPE,
+    expected,
+    'DTO keys or enum wire values changed. If this is intentional and backward-compatible for cached PWAs, update test/public-api.shape.json. Removing fields or renaming enum values is a breaking change.',
+  );
+});

--- a/frontend/src/app/shared/dto/index.ts
+++ b/frontend/src/app/shared/dto/index.ts
@@ -1,4 +1,2 @@
-import { TaskDTO } from './task.dto';
-import { UserDto } from './user.dto';
-
-export { TaskDTO, UserDto };
+export type { TaskDTO } from './task.dto';
+export type { UserDto } from './user.dto';

--- a/frontend/src/app/shared/dto/task.dto.ts
+++ b/frontend/src/app/shared/dto/task.dto.ts
@@ -1,10 +1,1 @@
-export interface TaskDTO {
-  id: string;
-  userId: string;
-  type: string;
-  title: string;
-  status: string;
-  imageId?: string;
-  createdAt: string;
-  modifiedAt: string;
-}
+export type { TaskDTO } from '@brainassistant/contracts';

--- a/frontend/src/app/shared/mappers/task.mapper.ts
+++ b/frontend/src/app/shared/mappers/task.mapper.ts
@@ -1,18 +1,18 @@
-import { TaskDTO } from '../dto/task.dto';
-import { Task, ETaskStatus, ETaskType } from '../models/task.model';
+import { TaskDTO } from '@brainassistant/contracts';
+import { Task } from '../models/task.model';
 
 export class TasksMapper {
   public static toModel(taskDto: TaskDTO): Task {
     return {
       id: taskDto.id,
       userId: taskDto.userId,
-      type: taskDto.type as ETaskType,
+      type: taskDto.type,
       title: taskDto.title,
-      status: taskDto.status as ETaskStatus,
+      status: taskDto.status,
       imageId: taskDto.imageId,
       createdAt: taskDto.createdAt,
       modifiedAt: taskDto.modifiedAt,
-    } as Task;
+    };
   }
 
   public static toDto(task: Task): TaskDTO {
@@ -31,6 +31,6 @@ export class TasksMapper {
       imageId: task.imageId,
       createdAt: task.createdAt,
       modifiedAt: task.modifiedAt,
-    } as TaskDTO;
+    };
   }
 }

--- a/frontend/src/app/shared/models/task.model.ts
+++ b/frontend/src/app/shared/models/task.model.ts
@@ -1,13 +1,5 @@
-export enum ETaskStatus {
-  Todo = 'TASK_STATUS_TODO',
-  Done = 'TASK_STATUS_DONE',
-  Cancel = 'TASK_STATUS_CANCEL',
-}
-
-export enum ETaskType {
-  Basic = 'TASK_TYPE_BASIC',
-  // TODO: More statuses will be here
-}
+import { ETaskStatus, ETaskType } from '@brainassistant/contracts';
+export { ETaskStatus, ETaskType };
 
 export type Task = {
   id: string;

--- a/scripts/smoke/http-smoke.mjs
+++ b/scripts/smoke/http-smoke.mjs
@@ -177,9 +177,9 @@ async function main() {
     body: {
       changeableObjectDto: {
         id: TASK_ID,
-        type: 'TASK',
+        type: 'TASK_TYPE_BASIC',
         title: TASK_TITLE,
-        status: 'OPEN',
+        status: 'TASK_STATUS_TODO',
       },
     },
   });


### PR DESCRIPTION
## Summary
- `TaskDTO.type` / `status` are now `ETaskType` / `ETaskStatus` with the same wire strings the PWA already sends (`TASK_TYPE_BASIC`, `TASK_STATUS_*`).
- Added a contracts public-API shape snapshot (`public-api.shape.ts` + `test/public-api.shape.json`) so removing DTO keys or renaming enum wire values fails `contracts` tests in CI before a cached PWA client breaks.
- Frontend reuses the shared enums; backend fixtures and compose-smoke send the real wire values instead of placeholder `TASK` / `OPEN`.

## Test plan
- [ ] `cd contracts; npm test`
- [ ] `cd backend; npx jest --runInBand --forceExit`
- [ ] `cd frontend; npm test`
- [ ] Confirm intentional DTO/enum changes require updating `contracts/test/public-api.shape.json`

Made with [Cursor](https://cursor.com)