### PR TITLE
test: nightly two-client Playwright e2e against live smoke backend

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,0 +1,53 @@
+name: Live Two-Client E2E
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  live-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install contracts
+        working-directory: ./contracts
+        run: npm ci
+
+      - name: Start smoke stack
+        run: node scripts/smoke/up.mjs
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: ./frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run live two-client e2e
+        working-directory: ./frontend
+        run: npm run e2e:live
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: live-e2e-report
+          path: frontend/playwright-report-live/
+          retention-days: 14
+
+      - name: Stop smoke stack
+        if: always()
+        run: node scripts/smoke/down.mjs

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -56,5 +56,6 @@ Thumbs.db
 # Playwright test results
 /test-results/
 /playwright-report/
+/playwright-report-live/
 /blob-report/
 /playwright/.cache/

--- a/frontend/e2e-live/README.md
+++ b/frontend/e2e-live/README.md
@@ -1,0 +1,41 @@
+# Live two-client e2e
+
+Playwright drives two isolated browser contexts against the **real** smoke backend (HTTPS + Mongo). The existing `e2e/` suite stays mocked and runs on every PR; this folder is nightly only.
+
+## What it checks
+
+One verified user, two devices (separate Playwright contexts). Create a task in A; B’s home list shows it after the 20s sync interval.
+
+No API mocks. No Google stub. Title-only tasks (live Google Drive is a placeholder and would 502).
+
+## Prerequisites
+
+Docker Desktop (or Engine) must be running so `docker-compose.smoke.yml` can boot.
+
+## Run locally
+
+From the repo root, start the smoke stack and leave it up:
+
+```bash
+node scripts/smoke/up.mjs
+```
+
+From `frontend/`:
+
+```bash
+npm run e2e:live
+```
+
+That serves Angular with `proxy.live.conf.json` (`/api` → `https://127.0.0.1:3443`) and runs `e2e-live/two-client-sync.spec.ts`.
+
+Tear down:
+
+```bash
+node scripts/smoke/down.mjs
+```
+
+Alternatively, API-only smoke (`node scripts/smoke/run.mjs`) with `SMOKE_KEEP_UP=1` also leaves the same compose project (`ba-smoke`) running.
+
+## CI
+
+`.github/workflows/live-e2e.yml` runs on a nightly schedule (`0 4 * * *`) and `workflow_dispatch`. It is not on every PR — the smoke image build is slow, and this spec waits on the 20s client sync tick.

--- a/frontend/e2e-live/two-client-sync.spec.ts
+++ b/frontend/e2e-live/two-client-sync.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import {
+  createTaskWithTitle,
+  loginWithPassword,
+  seedVerifiedUser,
+} from './utils/live-flow.util';
+
+test('task created on one device appears on the other after sync', async ({ browser }) => {
+  const user = await seedVerifiedUser();
+  const title = `Live sync task ${Date.now()}`;
+
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  try {
+    await loginWithPassword(pageA, user.email, user.password);
+    await loginWithPassword(pageB, user.email, user.password);
+
+    await createTaskWithTitle(pageA, title);
+
+    await expect(pageB.locator('[data-test="task-tile"]', { hasText: title })).toBeVisible({
+      timeout: 30_000,
+    });
+  } finally {
+    await contextA.close();
+    await contextB.close();
+  }
+});

--- a/frontend/e2e-live/utils/live-flow.util.ts
+++ b/frontend/e2e-live/utils/live-flow.util.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { expect, request as playwrightRequest, type Page } from '@playwright/test';
+
+function repoRoot(): string {
+  const cwd = process.cwd();
+  if (fs.existsSync(path.join(cwd, 'docker-compose.smoke.yml'))) {
+    return cwd;
+  }
+  return path.resolve(cwd, '..');
+}
+
+const REPO_ROOT = repoRoot();
+const COMPOSE_FILE = process.env.SMOKE_COMPOSE_FILE ?? 'docker-compose.smoke.yml';
+const COMPOSE_PROJECT = process.env.SMOKE_COMPOSE_PROJECT ?? 'ba-smoke';
+const SMOKE_BASE_URL = process.env.SMOKE_BASE_URL ?? 'https://127.0.0.1:3443';
+
+export type SeededUser = {
+  email: string;
+  password: string;
+};
+
+function mongosh(evalJs: string): string {
+  return execFileSync(
+    'docker',
+    [
+      'compose',
+      '-p',
+      COMPOSE_PROJECT,
+      '-f',
+      COMPOSE_FILE,
+      'exec',
+      '-T',
+      'db',
+      'mongosh',
+      '--quiet',
+      '-u',
+      'smoke',
+      '-p',
+      'smoke-password',
+      '--authenticationDatabase',
+      'admin',
+      'ba',
+      '--eval',
+      evalJs,
+    ],
+    { encoding: 'utf8', cwd: REPO_ROOT },
+  ).trim();
+}
+
+export async function seedVerifiedUser(): Promise<SeededUser> {
+  const email = `live-e2e-${Date.now()}@example.com`;
+  const password = 'password123';
+
+  const api = await playwrightRequest.newContext({
+    baseURL: SMOKE_BASE_URL,
+    ignoreHTTPSErrors: true,
+  });
+
+  try {
+    const signup = await api.post('/api/auth/signup', {
+      data: {
+        email,
+        firstName: 'Live',
+        lastName: 'E2E',
+        password,
+      },
+    });
+    if (!signup.ok()) {
+      throw new Error(`signup failed: ${signup.status()} ${await signup.text()}`);
+    }
+  } finally {
+    await api.dispose();
+  }
+
+  mongosh(`db.users.updateOne({ username: '${email}' }, { $set: { verified: true } })`);
+
+  return { email, password };
+}
+
+export async function loginWithPassword(page: Page, email: string, password: string): Promise<void> {
+  await page.goto('/');
+  await page.locator('[data-test="login-email"]').fill(email);
+  await page.locator('[data-test="login-password"]').fill(password);
+  await page.locator('[data-test="login-submit"]').click();
+  await expect(page.locator('[data-test="new-task-btn"]')).toBeVisible();
+}
+
+export async function createTaskWithTitle(page: Page, title: string): Promise<void> {
+  await page.click('[data-test="new-task-btn"]');
+  await page.waitForURL('/task/TASK_VIEW_MODE_CREATE');
+  await page.fill('[data-test="task-title-input"]', title);
+
+  const applyButton = page.locator('[data-test="apply-changes-btn"]');
+  await expect(applyButton).toBeEnabled();
+
+  const postPromise = page.waitForResponse(
+    response =>
+      response.url().includes('/api/sync/task') && response.request().method() === 'POST',
+  );
+  await applyButton.click();
+  const post = await postPromise;
+  if (!post.ok()) {
+    throw new Error(`create task failed: ${post.status()} ${await post.text()}`);
+  }
+
+  await page.waitForURL(/\/(home)?$/);
+  await expect(page.locator('[data-test="task-tile"]', { hasText: title })).toBeVisible();
+}

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -9,7 +9,7 @@ module.exports = {
   ...presetConfig,
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
   testMatch: ['<rootDir>/tests/**/*.spec.ts'],
-  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/', '<rootDir>/e2e/'],
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/', '<rootDir>/e2e/', '<rootDir>/e2e-live/'],
   transformIgnorePatterns: [
     'node_modules/(?!(.*\\.mjs$|@angular/common/locales/.*\\.js$|uuid|mime))',
   ],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,8 @@
     "ng": "ng",
     "start": "ng serve",
     "start:e2e": "ng serve --configuration e2e",
+    "start:live-e2e": "ng serve --proxy-config proxy.live.conf.json",
+    "e2e:live": "npx playwright test -c playwright.live.config.js",
     "build-prod": "ng build --configuration production --output-path dist/app",
     "build-dev": "ng build --output-path dist/app --poll 500 --watch",
     "build:cap": "ng build --configuration capacitor && npx cap sync",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -54,5 +54,6 @@ export default defineConfig({
   testIgnore: [
     '**/tests/**',
     '**/src/**',
+    '**/e2e-live/**',
   ],
 });

--- a/frontend/playwright.live.config.js
+++ b/frontend/playwright.live.config.js
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Live two-client e2e against the smoke Docker backend.
+ * Does not use the mocked `e2e/` suite or `start:e2e` stubs.
+ */
+export default defineConfig({
+  testDir: './e2e-live',
+  timeout: 90_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: [
+    ['html', { outputFolder: 'playwright-report-live' }],
+    ['list'],
+    ...(process.env.CI ? [['github']] : []),
+  ],
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npm run start:live-e2e',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'live-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 375, height: 667 },
+      },
+    },
+  ],
+  testMatch: '**/*.spec.ts',
+});

--- a/frontend/proxy.live.conf.json
+++ b/frontend/proxy.live.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "https://127.0.0.1:3443",
+    "secure": false,
+    "changeOrigin": true
+  }
+}

--- a/frontend/src/app/mobile-app/components/screens/mb-login-screen/mb-login-screen.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-login-screen/mb-login-screen.component.html
@@ -6,6 +6,7 @@
     <mat-form-field class="login-form__email" floatLabel="never">
       <input
         id="emailInput"
+        data-test="login-email"
         autofocus
         matInput
         placeholder="Email"
@@ -18,6 +19,7 @@
     <mat-form-field class="login-form__password" floatLabel="never">
       <input
         id="passwordInput"
+        data-test="login-password"
         type="password"
         matInput
         placeholder="Password"
@@ -30,6 +32,7 @@
     </mat-form-field>
     <button
       id="submitBtn"
+      data-test="login-submit"
       class="login-form__btn green-btn"
       type="submit"
       [disabled]="form.invalid"

--- a/scripts/smoke/README.md
+++ b/scripts/smoke/README.md
@@ -25,6 +25,18 @@ Leave the stack up after a pass:
 $env:SMOKE_KEEP_UP='1'; node scripts/smoke/run.mjs
 ```
 
+Boot the stack without HTTP checks (for live Playwright e2e):
+
+```bash
+node scripts/smoke/up.mjs
+```
+
+Tear it down:
+
+```bash
+node scripts/smoke/down.mjs
+```
+
 Re-run only the HTTP checks against an already-up stack:
 
 ```bash
@@ -34,6 +46,8 @@ node scripts/smoke/http-smoke.mjs
 ## CI
 
 `.github/workflows/compose-smoke.yml` runs on a nightly schedule and `workflow_dispatch`. It is intentionally not on every PR — image builds are slow.
+
+Live two-client Playwright (UI, two browser contexts) uses the same stack: `node scripts/smoke/up.mjs` then `npm run e2e:live` in `frontend/`. See `frontend/e2e-live/README.md` and `.github/workflows/live-e2e.yml`.
 
 ## Notes
 

--- a/scripts/smoke/compose.mjs
+++ b/scripts/smoke/compose.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Shared docker compose helpers for smoke / live e2e.
+ */
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const ROOT = path.resolve(__dirname, '../..');
+export const COMPOSE_FILE = 'docker-compose.smoke.yml';
+export const COMPOSE_PROJECT = 'ba-smoke';
+export const CERT_DIR = path.join(__dirname, 'certs');
+export const SMOKE_BASE_URL = 'https://127.0.0.1:3443';
+
+export function run(cmd, args, opts = {}) {
+  console.log(`[smoke] ${cmd} ${args.join(' ')}`);
+  const result = spawnSync(cmd, args, {
+    cwd: ROOT,
+    stdio: 'inherit',
+    shell: false,
+    ...opts,
+  });
+  return result.status ?? 1;
+}
+
+export function ensureCerts() {
+  fs.mkdirSync(CERT_DIR, { recursive: true });
+  const crt = path.join(CERT_DIR, 'server.crt');
+  const key = path.join(CERT_DIR, 'server.key');
+  if (fs.existsSync(crt) && fs.existsSync(key)) {
+    console.log('[smoke] reusing existing smoke TLS certs');
+    return;
+  }
+
+  console.log('[smoke] generating self-signed TLS certs via openssl container');
+  const status = run('docker', [
+    'run',
+    '--rm',
+    '-v',
+    `${CERT_DIR}:/certs`,
+    'alpine/openssl',
+    'req',
+    '-x509',
+    '-nodes',
+    '-newkey',
+    'rsa:2048',
+    '-keyout',
+    '/certs/server.key',
+    '-out',
+    '/certs/server.crt',
+    '-days',
+    '1',
+    '-subj',
+    '/CN=localhost',
+  ]);
+  if (status !== 0) {
+    process.exit(status);
+  }
+}
+
+export function compose(...args) {
+  return run('docker', ['compose', '-p', COMPOSE_PROJECT, '-f', COMPOSE_FILE, ...args]);
+}

--- a/scripts/smoke/down.mjs
+++ b/scripts/smoke/down.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { compose } from './compose.mjs';
+
+process.exit(compose('down', '-v'));

--- a/scripts/smoke/run.mjs
+++ b/scripts/smoke/run.mjs
@@ -3,67 +3,12 @@
  * Boots docker-compose.smoke.yml, runs http-smoke.mjs, then tears down.
  * Cross-platform (Windows / Linux / macOS) via docker + node.
  */
-import { spawnSync } from 'child_process';
-import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { COMPOSE_FILE, COMPOSE_PROJECT, compose, ensureCerts, run } from './compose.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT = path.resolve(__dirname, '../..');
-const COMPOSE_FILE = 'docker-compose.smoke.yml';
-const COMPOSE_PROJECT = 'ba-smoke';
-const CERT_DIR = path.join(__dirname, 'certs');
 const KEEP_UP = process.env.SMOKE_KEEP_UP === '1';
-
-function run(cmd, args, opts = {}) {
-  console.log(`[smoke-run] ${cmd} ${args.join(' ')}`);
-  const result = spawnSync(cmd, args, {
-    cwd: ROOT,
-    stdio: 'inherit',
-    shell: false,
-    ...opts,
-  });
-  return result.status ?? 1;
-}
-
-function ensureCerts() {
-  fs.mkdirSync(CERT_DIR, { recursive: true });
-  const crt = path.join(CERT_DIR, 'server.crt');
-  const key = path.join(CERT_DIR, 'server.key');
-  if (fs.existsSync(crt) && fs.existsSync(key)) {
-    console.log('[smoke-run] reusing existing smoke TLS certs');
-    return;
-  }
-
-  console.log('[smoke-run] generating self-signed TLS certs via openssl container');
-  const status = run('docker', [
-    'run',
-    '--rm',
-    '-v',
-    `${CERT_DIR}:/certs`,
-    'alpine/openssl',
-    'req',
-    '-x509',
-    '-nodes',
-    '-newkey',
-    'rsa:2048',
-    '-keyout',
-    '/certs/server.key',
-    '-out',
-    '/certs/server.crt',
-    '-days',
-    '1',
-    '-subj',
-    '/CN=localhost',
-  ]);
-  if (status !== 0) {
-    process.exit(status);
-  }
-}
-
-function compose(...args) {
-  return run('docker', ['compose', '-p', COMPOSE_PROJECT, '-f', COMPOSE_FILE, ...args]);
-}
 
 ensureCerts();
 

--- a/scripts/smoke/up.mjs
+++ b/scripts/smoke/up.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Generate certs if needed, boot docker-compose.smoke.yml, wait until HTTPS backend answers.
+ */
+import https from 'https';
+import { compose, ensureCerts, SMOKE_BASE_URL } from './compose.mjs';
+
+const agent = new https.Agent({ rejectUnauthorized: false });
+
+function ping() {
+  return new Promise((resolve, reject) => {
+    const req = https.request(SMOKE_BASE_URL, { method: 'GET', agent }, res => {
+      res.resume();
+      resolve(res.statusCode ?? 0);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function waitForBackend(timeoutMs = 180_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const status = await ping();
+      if (status === 200) {
+        console.log(`[smoke-up] backend up at ${SMOKE_BASE_URL}`);
+        return;
+      }
+    } catch {
+      // still booting
+    }
+    await new Promise(r => setTimeout(r, 2000));
+  }
+  console.error(`[smoke-up] backend not reachable at ${SMOKE_BASE_URL} within ${timeoutMs}ms`);
+  process.exit(1);
+}
+
+ensureCerts();
+const upStatus = compose('up', '-d', '--build');
+if (upStatus !== 0) {
+  process.exit(upStatus);
+}
+await waitForBackend();


### PR DESCRIPTION
## Summary
- Adds a live Playwright spec: two isolated Chromium contexts log in as the same verified user; a task created on A must appear on B's home after the 20s sync tick.
- Serves Angular with `proxy.live.conf.json` so the browser stays same-origin (`/api` → smoke HTTPS `:3443`). The mocked `e2e/` suite and PR Playwright job are unchanged.
- Nightly workflow `live-e2e.yml` (`0 4 * * *` + `workflow_dispatch`) boots `scripts/smoke/up.mjs`, runs `npm run e2e:live`, then `down.mjs`. Not on every PR.

## Test plan
- [ ] Docker running: `node scripts/smoke/up.mjs` then `cd frontend; npm run e2e:live`
- [ ] Confirm mocked `npm run e2e` still starts `start:e2e` and ignores `e2e-live/`
- [ ] After merge, run the `Live Two-Client E2E` workflow via `workflow_dispatch`
- [ ] `node scripts/smoke/down.mjs` tears the stack down

Made with [Cursor](https://cursor.com)