### PR TITLE
fix: return TaskDTO from PATCH and type domain Task with enums.

### DIFF
--- a/backend/src/modules/sync/usecases/task/update/update-task.controller.ts
+++ b/backend/src/modules/sync/usecases/task/update/update-task.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { TaskDTO, SendChangeContract } from '@brainassistant/contracts';
 import { UserPersistent } from '../../../../../shared/domain/models/user.js';
 import { BaseController } from '../../../../../shared/infra/http/models/base-controller.js';
+import { TaskMapper } from '../../../../../shared/mappers/task.mapper.js';
 import { UpdateTask } from './update-task.usecase.js';
 
 export class UpdateTaskController extends BaseController {
@@ -26,7 +27,7 @@ export class UpdateTaskController extends BaseController {
       });
 
       if (result.isSuccess) {
-        this.ok(res);
+        this.ok(res, TaskMapper.toDTO(result.getValue()));
       } else {
         const error = result.error;
 

--- a/backend/src/modules/sync/usecases/task/update/update-task.usecase.ts
+++ b/backend/src/modules/sync/usecases/task/update/update-task.usecase.ts
@@ -1,6 +1,7 @@
 import { UseCase } from '../../../../../shared/core/UseCase.js';
 import { Result } from '../../../../../shared/core/result.js';
 import { TaskDTO } from '@brainassistant/contracts';
+import { Task } from '../../../../../shared/domain/models/task.js';
 import { TaskRepoService } from '../../../../../shared/repo/task-repo.service.js';
 import { UpdateTaskError, UpdateTaskErrors } from './update-task.errors.js';
 
@@ -9,11 +10,11 @@ type Request = {
   dto: TaskDTO;
 };
 
-type Response = Result<void | never, UpdateTaskError>;
+export type UpdateTaskResult = Result<Task, UpdateTaskError>;
 
-export class UpdateTask implements UseCase<Request, Promise<Response>> {
+export class UpdateTask implements UseCase<Request, Promise<UpdateTaskResult>> {
   constructor(private readonly taskRepoService: TaskRepoService) {}
-  public async execute(req: Request): Promise<Response> {
+  public async execute(req: Request): Promise<UpdateTaskResult> {
     const userId = req.userId;
     const taskDto = req.dto;
 
@@ -37,6 +38,6 @@ export class UpdateTask implements UseCase<Request, Promise<Response>> {
 
     await this.taskRepoService.save(task);
 
-    return Result.ok<void, never>();
+    return Result.ok(task);
   }
 }

--- a/backend/src/shared/domain/models/task.ts
+++ b/backend/src/shared/domain/models/task.ts
@@ -1,3 +1,4 @@
+import { ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import { AggregateRoot } from '../AggregateRoot.js';
 import { UniqueEntityID } from '../UniqueEntityID.js';
 import { Result } from '../../core/result.js';
@@ -12,16 +13,24 @@ export enum ETaskError {
 
 export interface ITaskProps {
   userId: string;
-  type: string; // #TODO need to be special TYPE
+  type: ETaskType;
   title: string;
-  status: string; // #TODO need to be special TYPE
+  status: ETaskStatus;
   imageId?: string;
   createdAt: Date;
   modifiedAt: Date;
 }
 
-export interface TaskPresitant extends ITaskProps {
+/** Mongo document shape: type/status are stored as strings (ETaskType / ETaskStatus wire values). */
+export interface TaskPresitant {
   _id?: string;
+  userId: string;
+  type: string;
+  title: string;
+  status: string;
+  imageId?: string;
+  createdAt: Date;
+  modifiedAt: Date;
 }
 
 export class Task extends AggregateRoot<ITaskProps> {
@@ -36,7 +45,7 @@ export class Task extends AggregateRoot<ITaskProps> {
     return this.props.userId;
   }
 
-  get type(): string {
+  get type(): ETaskType {
     return this.props.type;
   }
 
@@ -44,7 +53,7 @@ export class Task extends AggregateRoot<ITaskProps> {
     return this.props.title;
   }
 
-  get status(): string {
+  get status(): ETaskStatus {
     return this.props.status;
   }
 

--- a/backend/src/shared/infra/database/mongodb/task.model.ts
+++ b/backend/src/shared/infra/database/mongodb/task.model.ts
@@ -8,9 +8,9 @@ export interface TaskDocument
 const TaskSchema = new Schema({
   _id: { type: String, require: true },
   userId: { type: String, require: true },
-  type: { type: String, require: true }, // #TODO need to be a special TYPE
+  type: { type: String, require: true }, // ETaskType wire value
   title: { type: String, require: true },
-  status: { type: String, require: true }, // #TODO need to be a special TYPE
+  status: { type: String, require: true }, // ETaskStatus wire value
   imageId: { type: String, require: false },
   createdAt: { type: Date, require: true },
   modifiedAt: { type: Date, require: true },

--- a/backend/src/shared/mappers/task.mapper.ts
+++ b/backend/src/shared/mappers/task.mapper.ts
@@ -8,7 +8,15 @@ export class TaskMapper {
     const { userId, type, title, status, imageId, _id, createdAt, modifiedAt } = raw;
 
     const taskOrError = Task.reconstitute(
-      { userId, type, title, status, imageId, createdAt, modifiedAt },
+      {
+        userId,
+        type: type as ETaskType,
+        title,
+        status: status as ETaskStatus,
+        imageId,
+        createdAt,
+        modifiedAt,
+      },
       new UniqueEntityID(_id),
     );
 
@@ -38,9 +46,9 @@ export class TaskMapper {
     return {
       id: task.id.toString(),
       userId: task.userId,
-      type: task.type as ETaskType,
+      type: task.type,
       title: task.title,
-      status: task.status as ETaskStatus,
+      status: task.status,
       imageId: task.imageId,
       createdAt: task.createdAt.toISOString(),
       modifiedAt: task.modifiedAt.toISOString(),

--- a/backend/test/integration/sync/task-update.int.spec.ts
+++ b/backend/test/integration/sync/task-update.int.spec.ts
@@ -56,7 +56,16 @@ describe('Integration: UpdateTask (Controller -> UseCase -> Repo -> MongoDB)', (
       .set('Accept', 'application/json');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({});
+    expect(res.body).toMatchObject({
+      id: created.id,
+      userId: created.userId,
+      type: created.type,
+      title: 'Updated task title',
+      status: created.status,
+    });
+    expect(res.body.createdAt).toBe(created.createdAt);
+    expect(typeof res.body.modifiedAt).toBe('string');
+    expect(res.body.modifiedAt).not.toBe(created.modifiedAt);
 
     const persisted = await models.TaskModel.findById(created.id).lean();
     expect(persisted).toMatchObject({

--- a/backend/test/unit/domain/task.spec.ts
+++ b/backend/test/unit/domain/task.spec.ts
@@ -28,6 +28,8 @@ describe('Task', () => {
       expect(result.isSuccess).toBe(true);
       const task = result.getValue();
       expect(task.title).toBe('Valid task title');
+      expect(task.type).toBe(ETaskType.Basic);
+      expect(task.status).toBe(ETaskStatus.Todo);
       expect(task.createdAt).toEqual(new Date('2025-01-15T12:00:00.000Z'));
       expect(task.modifiedAt).toEqual(new Date('2025-01-15T12:00:00.000Z'));
     });

--- a/backend/test/unit/mappers/task.mapper.spec.ts
+++ b/backend/test/unit/mappers/task.mapper.spec.ts
@@ -71,6 +71,8 @@ describe('TaskMapper', () => {
 
       expect(dto.id).toBe('task-123');
       expect(dto.userId).toBe('user-1');
+      expect(dto.type).toBe(ETaskType.Basic);
+      expect(dto.status).toBe(ETaskStatus.Todo);
       expect(dto.createdAt).toBe('2025-01-15T12:00:00.000Z');
       expect(dto.modifiedAt).toBe('2025-01-15T12:00:00.000Z');
       expect('_id' in dto).toBe(false);

--- a/contracts/src/contracts/send-change.contract.ts
+++ b/contracts/src/contracts/send-change.contract.ts
@@ -3,10 +3,10 @@ import { ChangeableObjectDTO } from "../dto";
 /**
  * Send Change Contract
  * Used for POST/PATCH/DELETE requests to sync endpoints
- * 
+ *
  * Examples:
  * - POST /api/sync/task { changeableObjectDto: TaskDTO } → Returns TaskDTO
- * - PATCH /api/sync/task { changeableObjectDto: TaskDTO } → Returns void
+ * - PATCH /api/sync/task { changeableObjectDto: TaskDTO } → Returns TaskDTO
  * - DELETE /api/sync/task/:id → Returns void
  */
 export namespace SendChangeContract {
@@ -20,11 +20,11 @@ export namespace SendChangeContract {
 
   /**
    * Response for sending a change to the server
-   * 
-   * Returns the created entity for POST requests.
-   * This confirms what the server actually saved (server is source of truth).
-   * 
-   * PATCH and DELETE answer 200 with no payload.
+   *
+   * POST and PATCH return the saved entity (server is source of truth).
+   * Cached PWAs that ignore the PATCH body stay compatible.
+   *
+   * DELETE answers 200 with no payload.
    */
   export type Response<T extends ChangeableObjectDTO = ChangeableObjectDTO> = T | void;
 }

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,386 +1,54 @@
-# Frontend E2E Tests
+# Frontend E2E tests (mocked API)
 
-## Overview
+Playwright drives the real UI against a **mocked** backend. Specs live in this folder and run on every PR (`npm run e2e` from `frontend/`).
 
-This directory contains end-to-end (E2E) tests using Playwright that validate the entire user journey from UI interactions to expected outcomes. Tests run against a real browser with mocked backend responses.
+Live two-client tests against a real backend are **not** here — see `frontend/e2e-live/`.
 
-## Test Structure
+## Layout
 
 ```
 e2e/
 ├── assets/
-│   └── test-img.jpg              # Test image fixture for upload tests
+│   └── test-img.jpg
 ├── stubs/
-│   ├── task-stubs.ts             # Mock task data
-│   └── user-stubs.ts             # Mock user data
+│   ├── sign-in-with-google-btn.component.ts
+│   └── device-camera.service.ts
 ├── utils/
-│   └── test-helpers.ts           # Reusable test utilities
-└── create-task.spec.ts           # Task creation E2E tests
+│   ├── api-mocks.util.ts
+│   └── task-flow.util.ts
+├── create-task.spec.ts
+├── edit-task.spec.ts
+├── delete-task.spec.ts
+└── sync-error.spec.ts
 ```
 
-## Running Tests
+Auth and the device camera are swapped at build time via `fileReplacements` in the `e2e` configuration of `angular.json`. HTTP is mocked in `utils/api-mocks.util.ts` — call `setupApiMocks(page)` at the start of a spec; do not scatter `page.route` calls.
+
+## Selectors
+
+Target elements with `[data-test="..."]`. This project uses `data-test`, not `data-testid`. If a control has no hook, add a `data-test` attribute to the template.
+
+```ts
+await page.click('[data-test="new-task-btn"]');
+```
+
+Text and role selectors are fine for user-visible copy, e.g. `page.getByText('Sign in with Google')`.
+
+## Run
+
+From `frontend/`:
 
 ```bash
-# Install dependencies (first time only)
-npm install
-npx playwright install --with-deps
-
-# Run all E2E tests
 npm run e2e
-
-# Run tests in headed mode (see the browser)
-npx playwright test --headed
-
-# Run tests in debug mode
-npx playwright test --debug
-
-# Run specific test file
-npx playwright test create-task.spec.ts
-
-# Run tests in specific browser
-npx playwright test --project=chromium
-npx playwright test --project=firefox
-npx playwright test --project=webkit
 ```
 
-## Test Philosophy
+That starts `npm run start:e2e` (see `playwright.config.js`) and runs the specs in this folder.
 
-### E2E Testing Approach
+## What the specs cover
 
-- ✅ **User-centric**: Tests simulate real user interactions (clicks, typing, navigation)
-- ✅ **Mocked backend**: Uses stubbed responses to avoid network dependency
-- ✅ **Visual validation**: Checks for visible elements, not internal state
-- ✅ **Isolated tests**: Each test is independent and can run in any order
+- **create-task** — Google stub login, title + image, POST `/api/sync/task`
+- **edit-task** — change title, PATCH `/api/sync/task`
+- **delete-task** — DELETE `/api/sync/task`
+- **sync-error** — POST fails with 500; the task stays on home (offline queue)
 
-### What We Test
-
-**Task Creation Tests** (`create-task.spec.ts`):
-- Happy path: Create task → verify it appears in the list
-- Form validation: Required fields, error messages
-- Image upload: Attach image → verify preview
-- User interactions: Clicks, typing, navigation
-
-## Test Patterns
-
-### 1. Page Object Model (Recommended)
-
-```typescript
-// pages/task-page.ts
-export class TaskPage {
-  constructor(private page: Page) {}
-
-  async navigateToTasks() {
-    await this.page.goto('/tasks');
-  }
-
-  async createTask(title: string) {
-    await this.page.fill('[data-testid="task-title"]', title);
-    await this.page.click('[data-testid="create-task-btn"]');
-  }
-
-  async getTaskByTitle(title: string) {
-    return this.page.locator(`[data-testid="task-item"]:has-text("${title}")`);
-  }
-}
-
-// create-task.spec.ts
-import { TaskPage } from './pages/task-page';
-
-test('should create a task', async ({ page }) => {
-  const taskPage = new TaskPage(page);
-  
-  await taskPage.navigateToTasks();
-  await taskPage.createTask('My new task');
-  
-  await expect(taskPage.getTaskByTitle('My new task')).toBeVisible();
-});
-```
-
-### 2. Mock API Responses
-
-```typescript
-test('should handle API errors gracefully', async ({ page }) => {
-  // Mock API failure
-  await page.route('**/api/tasks', (route) => {
-    route.fulfill({
-      status: 500,
-      body: JSON.stringify({ error: 'Server error' }),
-    });
-  });
-
-  await page.goto('/tasks');
-  await page.fill('[data-testid="task-title"]', 'Test task');
-  await page.click('[data-testid="create-task-btn"]');
-
-  // Verify error message is displayed
-  await expect(page.locator('[data-testid="error-message"]'))
-    .toContainText('Failed to create task');
-});
-```
-
-### 3. File Uploads
-
-```typescript
-test('should upload an image', async ({ page }) => {
-  await page.goto('/tasks/new');
-  
-  // Upload test image
-  const fileInput = page.locator('input[type="file"]');
-  await fileInput.setInputFiles('./e2e/assets/test-img.jpg');
-  
-  // Verify preview appears
-  await expect(page.locator('[data-testid="image-preview"]')).toBeVisible();
-});
-```
-
-### 4. Mobile Testing
-
-```typescript
-test.use({ 
-  viewport: { width: 375, height: 667 },  // iPhone SE
-  isMobile: true 
-});
-
-test('should work on mobile', async ({ page }) => {
-  await page.goto('/tasks');
-  
-  // Mobile-specific interactions
-  await page.tap('[data-testid="menu-btn"]');
-  await expect(page.locator('[data-testid="mobile-menu"]')).toBeVisible();
-});
-```
-
-## Best Practices
-
-### 1. Use Data Test IDs
-
-```html
-<!-- Good: Stable selector -->
-<button data-testid="create-task-btn">Create</button>
-
-<!-- Bad: Fragile selector -->
-<button class="btn btn-primary mt-3">Create</button>
-```
-
-```typescript
-// Test
-await page.click('[data-testid="create-task-btn"]');  // ✅ Stable
-await page.click('.btn.btn-primary.mt-3');           // ❌ Fragile
-```
-
-### 2. Wait for Elements Properly
-
-```typescript
-// ✅ Good: Auto-waiting
-await expect(page.locator('[data-testid="task-item"]')).toBeVisible();
-
-// ❌ Bad: Manual timeout
-await page.waitForTimeout(3000);
-```
-
-### 3. Clean Test Data
-
-```typescript
-test.beforeEach(async ({ page }) => {
-  // Clear local storage/cookies before each test
-  await page.context().clearCookies();
-  await page.evaluate(() => localStorage.clear());
-});
-```
-
-### 4. Descriptive Test Names
-
-```typescript
-// ✅ Good: Clear and specific
-test('should display error when task title is empty', async ({ page }) => {
-  // ...
-});
-
-// ❌ Bad: Vague
-test('task validation', async ({ page }) => {
-  // ...
-});
-```
-
-## Writing New Tests
-
-### 1. Create Test File
-
-```typescript
-// e2e/my-feature.spec.ts
-import { test, expect } from '@playwright/test';
-
-test.describe('My Feature', () => {
-  test.beforeEach(async ({ page }) => {
-    // Setup: Navigate to page, mock APIs, etc.
-    await page.goto('/my-feature');
-  });
-
-  test('should do something', async ({ page }) => {
-    // Act: User interactions
-    await page.click('[data-testid="action-btn"]');
-    
-    // Assert: Verify outcome
-    await expect(page.locator('[data-testid="result"]'))
-      .toContainText('Expected result');
-  });
-});
-```
-
-### 2. Add Test Stubs (if needed)
-
-```typescript
-// e2e/stubs/my-feature-stubs.ts
-export const mockFeatureData = {
-  id: '123',
-  name: 'Test Feature',
-  enabled: true,
-};
-```
-
-### 3. Add Test Helpers (if needed)
-
-```typescript
-// e2e/utils/my-helpers.ts
-import { Page } from '@playwright/test';
-
-export async function loginAsTestUser(page: Page) {
-  await page.goto('/login');
-  await page.fill('[data-testid="email"]', 'test@example.com');
-  await page.fill('[data-testid="password"]', 'password123');
-  await page.click('[data-testid="login-btn"]');
-  await page.waitForURL('/dashboard');
-}
-```
-
-## CI/CD Integration
-
-Tests run automatically in CI via `.github/workflows/frontend-tests.yml`:
-
-- Runs on push/PR to `main` or `develop` branches
-- Only triggers when frontend code changes
-- Uploads test reports as artifacts
-- Retention: 30 days
-
-### View Test Results
-
-1. **Locally**: `npx playwright show-report`
-2. **CI**: Download artifacts from GitHub Actions run
-
-## Debugging Failed Tests
-
-### 1. Run in Headed Mode
-
-```bash
-npx playwright test --headed
-```
-
-### 2. Use Debug Mode
-
-```bash
-npx playwright test --debug
-```
-
-### 3. Screenshot on Failure
-
-```typescript
-test('my test', async ({ page }) => {
-  // Playwright auto-captures screenshots on failure
-  // Manual screenshot:
-  await page.screenshot({ path: 'debug-screenshot.png' });
-});
-```
-
-### 4. Inspect with Playwright Inspector
-
-```bash
-npx playwright test --debug create-task.spec.ts
-```
-
-### 5. View Trace
-
-```typescript
-// playwright.config.js
-use: {
-  trace: 'on-first-retry',  // Capture trace on first retry
-}
-```
-
-```bash
-# View trace
-npx playwright show-trace trace.zip
-```
-
-## Configuration
-
-### Browser Configuration
-
-Edit `playwright.config.js`:
-
-```javascript
-export default {
-  // Run tests in parallel
-  workers: process.env.CI ? 1 : 4,
-  
-  // Timeout
-  timeout: 30000,
-  
-  // Browsers to test
-  projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
-    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
-    { name: 'mobile', use: { ...devices['iPhone 12'] } },
-  ],
-};
-```
-
-## Troubleshooting
-
-### Tests fail locally but pass in CI
-- Check for timing issues (use Playwright's auto-waiting)
-- Verify browser versions match
-- Check for environment-specific configurations
-
-### Flaky tests
-- Add proper waits using `expect().toBeVisible()`
-- Avoid `waitForTimeout()` - use deterministic waits
-- Check for race conditions in animations/transitions
-
-### Slow tests
-- Run fewer browser projects locally
-- Use `test.only()` to run specific tests during development
-- Consider splitting large test files
-
-### Element not found
-- Verify selector with Playwright Inspector
-- Check if element is in shadow DOM or iframe
-- Ensure element is visible (not hidden by CSS)
-
-## Common Selectors
-
-```typescript
-// By data-testid (recommended)
-page.locator('[data-testid="task-title"]')
-
-// By role (accessible)
-page.getByRole('button', { name: 'Create' })
-page.getByRole('textbox', { name: 'Task title' })
-
-// By text
-page.getByText('My Task')
-
-// By placeholder
-page.getByPlaceholder('Enter task title')
-
-// By label
-page.getByLabel('Task title')
-```
-
-## Resources
-
-- [Playwright Documentation](https://playwright.dev/)
-- [Playwright Best Practices](https://playwright.dev/docs/best-practices)
-- [Playwright API Reference](https://playwright.dev/docs/api/class-playwright)
-- [Testing Library Principles](https://testing-library.com/docs/guiding-principles/)
-
+Assert what the user can see and the outgoing request payload (`waitForResponse` then `request().postDataJSON()`). Do not reach into NGXS or component internals. Do not use `page.waitForTimeout()`.

--- a/frontend/e2e/utils/api-mocks.util.ts
+++ b/frontend/e2e/utils/api-mocks.util.ts
@@ -38,8 +38,8 @@ function parseSendChangeTask(postData: string | null): TaskDTO | null {
  * Mocks backend API routes so E2E specs run without a live server.
  *
  * Statuses and response bodies must mirror the real backend, which is pinned by the
- * integration specs in `backend/test/integration/`. Only `POST /api/sync/task` returns
- * an entity; update and delete answer 200 with no payload.
+ * integration specs in `backend/test/integration/`. POST and PATCH `/api/sync/task`
+ * return the saved TaskDTO; DELETE answers 200 with no payload.
  */
 export async function setupApiMocks(
   page: Page,
@@ -75,7 +75,9 @@ export async function setupApiMocks(
     }
 
     if (url.includes('/api/sync/task') && method === 'PATCH') {
-      await route.fulfill(json(200, {}));
+      const task = parseSendChangeTask(request.postData());
+      const body: SendChangeContract.Response<TaskDTO> = task ?? undefined;
+      await route.fulfill(json(200, body ?? {}));
       return;
     }
 


### PR DESCRIPTION
## Summary
- PATCH `/api/sync/task` returns the saved `TaskDTO` (aligned with POST; DELETE stays empty). Additive for cached PWAs that ignore the body.
- Domain `Task.type` / `status` are `ETaskType` / `ETaskStatus`; cast only in `TaskMapper.toDomain` at the Mongo string boundary.
- Playwright mocks mirror the PATCH response; `frontend/e2e/README.md` documents the real layout and `data-test` (not `data-testid`).

## Test plan
- [ ] `cd contracts; npm run build; npm test`
- [ ] `cd backend; npx jest test/unit/mappers/task.mapper.spec.ts test/unit/domain/task.spec.ts test/integration/sync/task-update.int.spec.ts --runInBand`
- [ ] Confirm integration happy path asserts TaskDTO (title, preserved `createdAt`, new `modifiedAt`)
- [ ] Optional: `cd frontend; npm run e2e` — edit-task still passes with PATCH entity body