### PR TITLE
chore: bump Docker and GitHub Actions to Node 24 LTS

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: backend/package-lock.json
 

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run compose smoke
         run: node scripts/smoke/run.mjs

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24
 
 WORKDIR /app
 

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24
 
 WORKDIR /usr/src/app
 

--- a/backend/test/README.md
+++ b/backend/test/README.md
@@ -100,4 +100,4 @@ They live in `test/unit/`, named `<subject>.spec.ts`, and call the real class.
 
 ## CI
 
-`.github/workflows/backend-tests.yml` runs ESLint and Jest on push/PR when `backend/**` or `contracts/**` change (Node 18 and 20).
+`.github/workflows/backend-tests.yml` runs ESLint and Jest on push/PR when `backend/**` or `contracts/**` change (Node 24).

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Summary
- Raise backend/frontend Docker images from `node:20` to `node:24` (Active LTS; Node 20 is EOL).
- Point all GitHub Actions workflows at Node 24.
- Correct stale CI docs that still mentioned Node 18/20.

## Test plan
- [ ] Backend Tests workflow passes on this branch
- [ ] Frontend Tests workflow passes on this branch
- [ ] Compose smoke workflow passes (or confirm path filters still skip if unchanged)
- [ ] Locally optional: rebuild `backend` / `frontend` images and smoke `docker compose`
