### PR TITLE
fix: stop Material Icon names flashing before the font loads

### DIFF
--- a/frontend/ngsw-config.json
+++ b/frontend/ngsw-config.json
@@ -6,13 +6,7 @@
       "name": "app",
       "installMode": "prefetch",
       "resources": {
-        "files": [
-          "/favicon.ico",
-          "/index.html",
-          "/manifest.webmanifest",
-          "/*.css",
-          "/*.js"
-        ]
+        "files": ["/favicon.ico", "/index.html", "/manifest.webmanifest", "/*.css", "/*.js"]
       }
     },
     {
@@ -35,9 +29,14 @@
       "name": "material-icons",
       "installMode": "prefetch",
       "resources": {
-        "urls": [
-          "https://fonts.googleapis.com/icon?family=Material+Icons"
-        ]
+        "urls": ["https://fonts.googleapis.com/icon?family=Material+Icons&display=block"]
+      }
+    },
+    {
+      "name": "material-icon-files",
+      "installMode": "lazy",
+      "resources": {
+        "urls": ["https://fonts.gstatic.com/s/materialicons/**"]
       }
     }
   ]

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,21 +1,31 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8" />
     <title>App</title>
-    <base href="/"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com"/>
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&amp;display=swap" rel="stylesheet"/>
-    <link rel="preload" href="https://fonts.googleapis.com/icon?family=Material+Icons" as="style"/>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
-    <link rel="manifest" href="manifest.webmanifest">
-  <meta name="theme-color" content="#1976d2">
-</head>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons&amp;display=block"
+      rel="stylesheet"
+    />
+    <script>
+      if (document.fonts) {
+        document.fonts.load('24px "Material Icons"');
+      }
+    </script>
+    <link rel="manifest" href="manifest.webmanifest" />
+    <meta name="theme-color" content="#1976d2" />
+  </head>
   <body>
     <app-root></app-root>
     <noscript>Please enable JavaScript to continue using this application.</noscript>
-</body>
+  </body>
 </html>

--- a/frontend/src/scss/_material-icons.scss
+++ b/frontend/src/scss/_material-icons.scss
@@ -9,5 +9,5 @@
 
 .material-icons,
 .mat-icon {
-  font-family: 'Material Icons', 'Material Icons Fallback';
+  font-family: 'Material Icons', 'Material Icons Fallback', sans-serif;
 }

--- a/frontend/src/scss/_material-icons.scss
+++ b/frontend/src/scss/_material-icons.scss
@@ -1,0 +1,13 @@
+// Ligature icon fonts render the glyph name (e.g. "arrow_back") until the font
+// file is ready. .mat-icon is 24×24 with overflow:hidden, so that name is
+// truncated to a flash of "arrow". A 0%-size fallback keeps the letters invisible.
+@font-face {
+  font-family: 'Material Icons Fallback';
+  src: local('Roboto'), local('Arial'), local('Helvetica Neue'), local('Helvetica');
+  size-adjust: 0%;
+}
+
+.material-icons,
+.mat-icon {
+  font-family: 'Material Icons', 'Material Icons Fallback';
+}

--- a/frontend/src/scss/index.scss
+++ b/frontend/src/scss/index.scss
@@ -9,3 +9,4 @@
 @use 'breakpoints';
 @use 'typography';
 @use 'spacing';
+@use 'material-icons';


### PR DESCRIPTION
## Summary
- Material Icons use ligatures, so `<mat-icon>arrow_back</mat-icon>` shows the truncated word `arrow` until the `.woff2` arrives — usually on the first screen that uses `mat-icon` (create task, profile, sync).
- Start loading the font at page boot, use `font-display=block`, and keep ligature text invisible with a 0%-size fallback.
- Cache the actual icon font files in the service worker, not only the Google Fonts CSS.

## Test plan
- [ ] Hard-refresh (or open an incognito window) so the icon font is not already cached
- [ ] Open create-task: the camera and mic icons should appear as glyphs, not `image` / `mic`
- [ ] Open profile and sync: the back button should appear as an arrow, not the word `arrow`
- [ ] Open those screens a second time and confirm icons still render

Made with [Cursor](https://cursor.com)