### PR TITLE
fix: patch ip-address for Dependabot #270

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13509,15 +13509,11 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
@@ -14694,13 +14690,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "20.0.3",
@@ -19337,13 +19326,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
       "version": "12.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,6 +105,7 @@
     "@xmldom/xmldom": ">=0.8.15",
     "@humanfs/node": ">=0.16.8",
     "js-yaml@3": "3.15.2",
-    "js-yaml@4": "4.3.2"
+    "js-yaml@4": "4.3.2",
+    "ip-address": ">=10.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- Override frontend `ip-address` to `>=10.3.1` (resolved `10.7.0`).
- Closes Dependabot alert #270 (leading-zero octet decimal/octal mismatch).

## Test plan
- [x] `npm ci` in `frontend/`
- [ ] Confirm alert #270 auto-closes after merge

Made with [Cursor](https://cursor.com)