### PR TITLE
fix: patch brace-expansion for Dependabot #267

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9692,9 +9692,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -107,6 +107,7 @@
     "js-yaml@3": "3.15.2",
     "js-yaml@4": "4.3.2",
     "ip-address": ">=10.3.1",
-    "postcss": ">=8.5.23"
+    "postcss": ">=8.5.23",
+    "brace-expansion@2": "2.1.4"
   }
 }


### PR DESCRIPTION
## Summary
- Override frontend `brace-expansion@2` → `2.1.4`.
- Closes Dependabot alert #267 (and related 2.x brace-expansion alerts).

## Test plan
- [x] `npm ci` in `frontend/`
- [ ] Confirm alert #267 auto-closes after merge

Made with [Cursor](https://cursor.com)