### PR TITLE
fix: patch immutable for Dependabot #255

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13299,9 +13299,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,7 @@
     "ip-address": ">=10.3.1",
     "postcss": ">=8.5.23",
     "brace-expansion@2": "2.1.4",
-    "tar": ">=7.5.21"
+    "tar": ">=7.5.21",
+    "immutable": ">=5.1.8"
   }
 }


### PR DESCRIPTION
## Summary
- Override frontend `immutable` to `>=5.1.8`.
- Closes Dependabot alerts #255 / #254.

## Test plan
- [x] `npm ci` in `frontend/`
- [ ] Confirm related `immutable` alerts auto-close after merge

Made with [Cursor](https://cursor.com)