### PR TITLE
fix: patch piscina for Dependabot #235

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17451,13 +17451,16 @@
       }
     },
     "node_modules/piscina": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.8.0.tgz",
-      "integrity": "sha512-EZJb+ZxDrQf3dihsUL7p42pjNyrNIFJCrRHPMgxu/svsj+P3xS3fuEWp7k2+rfsavfl1N0G29b1HGs7J0m8rZA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.3.2.tgz",
+      "integrity": "sha512-vv7l/mM7B9WgrhDaudIqv1x6v4LOBRYYmpWGdWushhpbCmVHp11sUB2v4hj1CAeTGXVxuZFz6xOU1RalAiPKfQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=20.x"
+      },
       "optionalDependencies": {
-        "@napi-rs/nice": "^1.0.1"
+        "@napi-rs/nice": "^1.0.4"
       }
     },
     "node_modules/pkg-dir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -114,6 +114,7 @@
     "immutable": ">=5.1.8",
     "webpack-dev-server": ">=5.2.6",
     "sigstore": ">=4.1.1",
-    "@sigstore/core": ">=3.2.1"
+    "@sigstore/core": ">=3.2.1",
+    "piscina": ">=4.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- Override frontend `piscina` to `>=4.9.3`.
- Closes Dependabot alert #235.

## Test plan
- [x] `npm ci` in `frontend/`
- [ ] Confirm alert #235 auto-closes after merge

Made with [Cursor](https://cursor.com)