### PR TITLE
fix: patch @babel/runtime for Dependabot #129

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3057,7 +3057,6 @@
       "version": "7.26.10",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
       "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -13115,21 +13114,6 @@
         "@babel/runtime": "7.11.2"
       }
     },
-    "node_modules/get-blob-duration/node_modules/@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/get-blob-duration/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT"
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -18586,7 +18570,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regex-parser": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -118,6 +118,7 @@
     "piscina": ">=4.9.3",
     "form-data@4": ">=4.0.6",
     "@babel/core": ">=7.29.6",
+    "@babel/runtime": ">=7.26.10",
     "serialize-javascript": ">=7.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- Override frontend `@babel/runtime` to `>=7.26.10`.
- Closes Dependabot alert #129.

## Test plan
- [x] `npm ci` in `frontend/`
- [ ] Confirm alert #129 auto-closes after merge

Made with [Cursor](https://cursor.com)