### PR TITLE
chore: add Cursor agent skills for common workflows

### DIFF
--- a/.cursor/skills/add-e2e-test/SKILL.md
+++ b/.cursor/skills/add-e2e-test/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: add-e2e-test
+description: Workflow for writing a Playwright E2E spec against the Angular PWA with a mocked backend. Use when adding or updating specs in frontend/e2e, or after implementing a user-visible flow that needs end-to-end coverage.
+---
+
+# Add an E2E test
+
+Process only. Selector, mocking and waiting rules are in `.cursor/rules/testing-e2e.mdc` — follow them, do not restate them.
+
+Specs drive the real UI on the `e2e` build configuration against a fully mocked backend. Run from `frontend/`.
+
+## Checklist
+
+```
+- [ ] 1. Read the existing specs
+- [ ] 2. Make sure the elements are reachable
+- [ ] 3. Extend the central mocks
+- [ ] 4. Write the spec
+- [ ] 5. Run it
+```
+
+## 1. Read the existing specs
+
+`frontend/e2e/create-task.spec.ts` is the fullest flow; `edit-task`, `delete-task` and `sync-error` cover the variants. `frontend/e2e/README.md` describes the setup.
+
+Reuse `e2e/utils/task-flow.util.ts` before writing new navigation: `signIn(page)` and `createTaskWithTitle(page, title)` already handle the sign-in and create flows including their waits. Most specs need a task to exist but are not testing creation.
+
+## 2. Make sure the elements are reachable
+
+Every element the spec touches needs a `data-test` attribute — this project uses `data-test`, not `data-testid`. Missing hooks are added to the template, never worked around with CSS classes or DOM position.
+
+Native capabilities (Google sign-in, camera) are swapped at build time via `fileReplacements` in the `e2e` configuration of `frontend/angular.json`, pointing at `e2e/stubs/`. Covering a new native capability means adding a stub plus a `fileReplacements` entry — do not fake it inside the spec.
+
+Binary fixtures go in `e2e/assets/`.
+
+## 3. Extend the central mocks
+
+HTTP is mocked in one place: `e2e/utils/api-mocks.util.ts`. Call `await setupApiMocks(page)` at the start of the spec and add new routes to that util rather than scattering `page.route` calls.
+
+The mock must mirror the real backend, which the backend integration specs pin: same status codes (`POST /api/sync/task` answers 201, `PATCH` answers 200), same body shape, typed against `@brainassistant/contracts`. A mock that is more forgiving than the real API produces a green suite and a broken app.
+
+For failure paths, add an option to `SetupApiMocksOptions` the way `failTaskSync` does, instead of re-routing inside the spec.
+
+## 4. Write the spec
+
+Assert what the user can observe, plus what the app sent. To capture the request, register `page.waitForResponse(...)` **before** the click that triggers it, then inspect `request().postDataJSON()`.
+
+Rely on auto-waiting: `expect(locator).toBeVisible()` and `page.waitForURL(...)`. Never `page.waitForTimeout()`. Do not reach into NGXS state or component internals — that is what the state specs in `frontend/tests/unit/state/` are for.
+
+Keep specs independent: no shared state, no ordering assumptions.
+
+## 5. Run it
+
+```powershell
+npm run e2e
+npx playwright test e2e/<spec>.spec.ts
+npm run e2e:ui
+```
+
+`npm run e2e` starts the `e2e` dev server itself via the Playwright config; there is no need to run `start:e2e` separately.
+
+If a spec is flaky, the cause is almost always a missing wait on navigation or on the response — not a timing problem to be papered over with a timeout.
+
+`npm run e2e:live` runs the separate `e2e-live/` suite against a real backend. That is a different loop; do not put mocked specs there.

--- a/.cursor/skills/change-contract/SKILL.md
+++ b/.cursor/skills/change-contract/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: change-contract
+description: Workflow for editing the shared @brainassistant/contracts package - adding or changing DTOs, enums and endpoint contracts, rebuilding dist, and updating both apps. Use when a change touches contracts/src, an HTTP payload shape, or a type shared between frontend and backend.
+---
+
+# Change a shared contract
+
+Process only. Layout and compatibility rules are in `.cursor/rules/contracts.mdc` — follow them, do not restate them.
+
+`contracts/` is a separate npm package linked into both apps as `file:../contracts`, and **the apps import compiled `dist/`**. A source-only edit changes nothing until it is rebuilt. This is the step that gets forgotten and produces confusing "the type is right there" errors.
+
+## Checklist
+
+```
+- [ ] 1. Classify the change
+- [ ] 2. Edit contracts/src and export it
+- [ ] 3. Rebuild
+- [ ] 4. Update backend
+- [ ] 5. Update frontend
+- [ ] 6. Verify both apps
+- [ ] 7. Report compatibility
+```
+
+## 1. Classify the change
+
+Answer before writing code, because it decides whether the change is allowed as-is:
+
+- **Additive** — new optional field, new DTO, new enum member, new contract namespace. Safe.
+- **Breaking** — renaming a field, making an optional field required, removing anything, changing what an existing enum value means.
+
+The frontend is an offline PWA. Old clients keep running cached builds and hold data in the old shape in persisted NGXS state. A breaking change is not a refactor here; if one looks unavoidable, say so and describe what happens to old clients and already-stored data before implementing it.
+
+## 2. Edit `contracts/src` and export it
+
+- `src/dto/<name>.dto.ts` — payload shapes, `type` not `interface`
+- `src/enums/<name>.enum.ts` — enums crossing the wire
+- `src/contracts/<name>.contract.ts` — the per-endpoint namespace with `Request` / `Response`
+
+Add it to the folder barrel **and** `src/index.ts`. Anything not re-exported from `src/index.ts` does not exist as far as the apps are concerned.
+
+Keep the package types-only: no validation, no mappers, no runtime logic, no dependencies.
+
+## 3. Rebuild
+
+```powershell
+cd contracts; npm run build
+```
+
+Run `npm test` here too — it rebuilds and asserts the public API shape, which catches a missing barrel export immediately.
+
+## 4. Update backend
+
+Consume the contract at the controller boundary with explicit `FooContract.Request` / `FooContract.Response` annotations. Keep them even when inference would work; they document the public API.
+
+Map the DTO into use-case params in `*.mapper.ts`, and out of the domain in `shared/mappers/<entity>.mapper.ts` (`toDTO`). The contract type must not travel into the use case.
+
+## 5. Update frontend
+
+Update the API service in `shared/services/api/` and the mapper in `shared/mappers/`. Enums from contracts can be reused directly in `shared/models/`; DTOs are mapped to models and never stored in NGXS state as-is.
+
+If E2E mocks return this payload, update `frontend/e2e/utils/api-mocks.util.ts` — it is typed against the contract and mirrors the real backend's status codes.
+
+## 6. Verify both apps
+
+```powershell
+cd backend; npm run typecheck; npm test
+cd ../frontend; npm test; npm run build-prod
+```
+
+If either app cannot see a new export, the rebuild in step 3 did not happen or the barrel export is missing.
+
+## 7. Report compatibility
+
+Finish by stating explicitly whether the change is additive or breaking, and — when it is breaking — what an old cached client does when it meets the new payload.

--- a/.cursor/skills/change-mongodb-schema/SKILL.md
+++ b/.cursor/skills/change-mongodb-schema/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: change-mongodb-schema
+description: Workflow for adding, changing or removing a Mongoose field, schema or index, including impact on existing documents and offline clients. Use when editing anything under backend/src/shared/infra/database/mongodb or when a feature needs a new persisted field.
+---
+
+# Change a MongoDB schema
+
+Process only. Data-access rules are in `.cursor/rules/mongodb.mdc` — follow them, do not restate them.
+
+**This project has no migration tooling and no migration scripts.** Nothing rewrites existing documents when a schema changes. Combined with offline clients that sync against these shapes, that makes a schema edit a compatibility decision, not a typing exercise. Work through the questions below *before* editing the schema file.
+
+## Checklist
+
+```
+- [ ] 1. Classify the change
+- [ ] 2. Answer the four compatibility questions
+- [ ] 3. Edit schema + registry
+- [ ] 4. Mapper and domain
+- [ ] 5. Repo and queries
+- [ ] 6. Indexes
+- [ ] 7. Contract and client impact
+- [ ] 8. Tests
+- [ ] 9. Report the migration story
+```
+
+## 1. Classify the change
+
+- **Additive** — a new optional field on an existing schema, or a whole new schema. Low risk.
+- **Destructive** — renaming, removing, retyping a field, or changing what a stored value means. High risk, and the default answer is: add a new field instead and leave the old one alone.
+
+## 2. Answer the four compatibility questions
+
+Write the answers into your response. If you cannot answer one, stop and ask rather than guessing.
+
+1. **Existing documents** — what does a document written before this change look like now? Does reading it through the mapper produce `undefined` where the domain expects a value?
+2. **Backfill** — do old documents need a value? There is no migration runner, so the realistic options are: make it optional, default it in the mapper, or write a one-off script and say so explicitly.
+3. **Old clients** — an offline PWA client running a previous build syncs against this shape. Does it still parse what the server sends, and does the server still accept what it sends?
+4. **Persisted client state** — NGXS persists every slice to the device. If this field reaches the frontend model, old stored state lacks it; selectors and defaults must tolerate that.
+
+## 3. Edit schema and registry
+
+Schema in `backend/src/shared/infra/database/mongodb/<entity>.model.ts`.
+
+A new schema must also be added to `IDbModels` **and** the `models` object in that folder's `index.ts` — repos read models from the injected registry, so an unregistered model is invisible to them.
+
+Mind the id types: `Task` and `Client` use a string `_id`, `User` uses a real `ObjectId` converted in `user.repo.ts`. Be explicit about which you are dealing with.
+
+## 4. Mapper and domain
+
+Update `backend/src/shared/mappers/<entity>.mapper.ts` in all three directions you actually use (`toDomain`, `toPersistence`, `toDTO`). `toDomain` is where an absent legacy field must be handled — that is the boundary old documents come through.
+
+If the field is part of domain invariants, add its validation to the entity with `Guard` + `Result`, and add the failure to the entity's error enum.
+
+## 5. Repo and queries
+
+New queries need an explicit bound: a `userId` filter, a time window, or a limit. Prefer atomic operators over read-modify-write, and never query inside a loop.
+
+## 6. Indexes
+
+The existing schemas define no indexes at all. If you added a query that filters or sorts on a growing field — anything keyed by `userId`, `modifiedAt`, `occurredAt` — state whether an index is needed and add it deliberately. Do not add indexes speculatively.
+
+## 7. Contract and client impact
+
+If the field crosses the wire, it belongs in `contracts/` and needs the rebuild — follow `change-contract`. A stored field that is deliberately *not* exposed to clients is a fine outcome; say which one you chose.
+
+## 8. Tests
+
+Extend the integration spec for the flow that writes the field, and assert it by reading the document back through the model. If old documents are meant to keep working, add a case that seeds a document without the field and reads it back.
+
+```powershell
+cd backend; npm run typecheck; npm test
+```
+
+## 9. Report the migration story
+
+Finish with the concrete answers from step 2: what happens to existing documents, whether a backfill is needed, and what an old offline client sees. "It compiles" is not a migration story.

--- a/.cursor/skills/debug-sync-issue/SKILL.md
+++ b/.cursor/skills/debug-sync-issue/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: debug-sync-issue
+description: Diagnostic workflow for offline sync problems in the PWA - changes stuck in the queue, data not reaching the server, server changes not appearing, duplicated or vanishing tasks, clientId errors, images not uploading. Use when investigating anything about synchronization between the Angular client and the backend.
+---
+
+# Debug a sync issue
+
+A map plus a diagnosis order. Sync spans NGXS state, persisted device storage, an HTTP queue, the backend sync module and IndexedDB, so the usual failure is looking in the wrong layer for twenty minutes. Locate the layer first, then read code.
+
+## How sync actually runs
+
+`frontend/src/app/shared/state/sync.state.ts` is the engine. One cycle, triggered every 20 seconds (`SYNC_PERIOD`) by a timer started on `AppAction.Opened`, and also immediately whenever a change is queued:
+
+1. If there is no `clientId`, request one (`ClientIdService.releaseClientId()`).
+2. **Pull**: `ServerChangesService.fetch(clientId)` → dispatch `SyncAction.ServerChangesLoaded(changes)`; domain slices merge them.
+3. **Push**: iterate `state.changes` and send each via `ClientChangesService.send(change)`, dispatching `SyncAction.LocalChangeWasSynchronized(change)` to dequeue it.
+4. `lastTime` is stamped, then `ImageService.uploadImages()` flushes pending image blobs.
+
+Two behaviours to know before theorising:
+
+- **The push loop stops at the first failure.** A non-404 error dispatches `SyncAction.SyncinhriniziationWasFailed` and returns, leaving that change and everything behind it queued for the next tick. One poisoned change blocks the whole queue. (The action name is misspelled in the source — search for it exactly.)
+- **404 is special.** A 404 while pushing means the entity is gone server-side, so the client synthesizes a local delete. A 404 elsewhere in the cycle resets `clientId` to `null` and re-runs. Both paths are noted as relying on status codes alone, tickets BA-258.
+
+## Files by layer
+
+| Layer | File |
+|-------|------|
+| Engine, queue, retry | `shared/state/sync.state.ts`, `sync.action.ts` |
+| Outbound HTTP | `shared/services/api/client-changes.service.ts` |
+| Inbound HTTP | `shared/services/api/server-changes.service.ts` |
+| Client identity | `shared/services/api/client-id.service.ts` |
+| Merge of inbound changes | `shared/state/tasks.state.ts` (`SyncAction.ServerChangesLoaded`) |
+| Endpoints | `shared/constants/api-endpoints.const.ts` |
+| Images | `shared/services/application/image.service.ts`, `infrastructure/image-db.service.ts`, `database.service.ts` (`ba-db` / `images`) |
+| Online/offline flag | `app.component.ts` → `AppState.online` |
+| Backend | `backend/src/modules/sync/usecases/`, `routers/index.ts` |
+
+## Diagnosis order
+
+Work down this list; do not skip to the backend.
+
+1. **Is the change queued at all?** Inspect `sync.changes` in state. Empty means the domain slice never dispatched `ChangeForSyncOccurred` — the bug is in the feature, not in sync.
+2. **Is the cycle running?** `lastTime` should advance every 20 seconds. Frozen means the timer never started (no `AppAction.Opened`) or was cleared by `UserAction.LoggedOut` / `AppAction.UserNotAuthenticated`.
+3. **Is the queue stuck behind one change?** If `changes` keeps growing and the first entry never leaves, that first entry is failing. Look for `Sync Pending Change Error` in the console — it logs the change and the error.
+4. **Is it the request or the response?** Check the actual status. 401 means the JWT cookie is gone (an auth problem wearing a sync costume). 400 means the backend rejected the payload — compare against the DTO in `contracts/`. 404 triggers the special paths above.
+5. **Inbound only?** If pushing works but server changes never appear, the problem is in `fetch` or in the slice's `ServerChangesLoaded` handler, not in the queue.
+6. **Backend side.** Only now read `backend/src/modules/sync/usecases/` and check what the get-changes query is scoped by (`userId`, `modifiedAt`, `clientId`).
+
+## Two traps specific to this project
+
+**Persisted state.** `withNgxsStoragePlugin({ keys: '*' })` persists every slice, including the sync queue and `clientId`. A user's device can hold a queue written by an older build with an older shape. When reproducing, consider clearing site data — and when fixing, remember old stored queues must still be handled.
+
+**Images are not in NGXS.** Image blobs live in IndexedDB (`ba-db`, store `images`, `uploaded` index) and are uploaded at the end of the cycle. A task that syncs while its picture does not is an `ImageService` problem, not a sync-queue problem.
+
+## Confirm the fix with a test
+
+Reproduce in a spec rather than by hand:
+
+- queue and retry behaviour → `frontend/tests/unit/state/sync.state.spec.ts`
+- a failing push from the user's point of view → `frontend/e2e/sync-error.spec.ts`, which uses `setupApiMocks(page, { failTaskSync: true })`
+- the server contract → the integration specs in `backend/test/integration/sync/`
+
+Never "fix" sync by disabling the interval, widening a catch, or dropping changes from the queue. Queued changes are unsaved user data.

--- a/.cursor/skills/implement-backend-feature/SKILL.md
+++ b/.cursor/skills/implement-backend-feature/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: implement-backend-feature
+description: Step-by-step workflow for adding or changing a backend endpoint or business flow in the Express use-case architecture. Use when implementing a new API endpoint, use case, repository method or Mongoose-backed feature under backend/src/modules.
+---
+
+# Implement a backend feature
+
+Process only. What correct backend code looks like is defined in `.cursor/rules/backend-architecture.mdc`, `mongodb.mdc` and `typescript-type-vs-interface.mdc` — do not restate those rules, follow them.
+
+Run every command from `backend/`. The shell is PowerShell: separate commands with `;`, never `&&`.
+
+## Checklist
+
+```
+- [ ] 1. Read a neighbouring use case
+- [ ] 2. Decide the HTTP contract
+- [ ] 3. Persistence layer (only if new data is stored)
+- [ ] 4. Use-case folder
+- [ ] 5. Wire the route
+- [ ] 6. Integration test
+- [ ] 7. lint / typecheck / test
+- [ ] 8. Review the diff
+```
+
+## 1. Read a neighbouring use case first
+
+Open `backend/src/modules/sync/usecases/task/create/` and read all five files. It is the reference shape: `create-task.controller.ts`, `create-task.usecase.ts`, `create-task.errors.ts`, `create-task.mapper.ts`, `index.ts`.
+
+If the feature is close to an existing flow, mirror that flow instead of the reference. Naming varies slightly between modules (a few use `_index.ts`) — match the neighbours you are joining, not this document.
+
+## 2. Decide the HTTP contract
+
+If the endpoint is public-facing, its request and response types belong in `contracts/`, not in a local `*.dto.ts`. Follow `change-contract` for that part, including the rebuild step — the backend reads `contracts/dist/`, so a source-only contract edit is invisible.
+
+`auth` still uses local `*.dto.ts` files. Extending an existing auth flow may legitimately mean staying with the local DTO; a new endpoint should use contracts.
+
+## 3. Persistence layer (only if new data is stored)
+
+1. Schema in `backend/src/shared/infra/database/mongodb/<entity>.model.ts`.
+2. Register it in `IDbModels` **and** the `models` object in that folder's `index.ts` — repos resolve models from the injected registry.
+3. Mapper in `backend/src/shared/mappers/<entity>.mapper.ts` (`toDomain`, `toPersistence`, `toDTO`).
+4. Repo method in `backend/src/shared/repo/<entity>-repo.service.ts`.
+
+Changing an existing schema instead of adding one? Stop and follow `change-mongodb-schema` — there are no migrations in this project.
+
+## 4. Use-case folder
+
+Create `backend/src/modules/<module>/usecases/<name>/` and build it in dependency order:
+
+1. **Domain first.** Validation lives in the entity or value object via `Guard` + `Result`. Add the failure case to the entity's error enum. There is no validation library and no `*.validation.ts` layer.
+2. `<name>.errors.ts` — a `UseCaseError` subclass plus the `<Name>Errors` namespace, each error carrying its `httpCode`.
+3. `<name>.usecase.ts` — implements `UseCase<Params, Promise<Result>>`, takes repos and services through the constructor, returns `Result`. No Express types cross this boundary.
+4. `<name>.mapper.ts` — only when request-to-params mapping is non-trivial.
+5. `<name>.controller.ts` — extends `BaseController`, reads `req.user`, branches on `result.isSuccess`, keeps the `try/catch`.
+6. `index.ts` — the composition root. Instantiate repos and services, then the use case, then the controller, and export the controller singleton. There is no DI container; this file is the wiring.
+
+## 5. Wire the route
+
+Add the route in `backend/src/modules/<module>/routers/`. Routers hold no logic.
+
+A brand-new module also needs mounting in `backend/src/shared/infra/http/api/index.ts`. Check there whether the route belongs behind `isAuthenticated` — everything under `/api/sync` is.
+
+## 6. Integration test
+
+Integration is the default in this project; follow `write-integration-test`. Cover the happy path, the validation failure, and the failure of any external service the use case calls.
+
+## 7. Verify
+
+```powershell
+npm run lint:check
+npm run typecheck
+npm test
+```
+
+Narrow the test run while iterating: `npm test -- <spec-file>`. There is no `build` script — `typecheck` is the compile check, and `compile` would start the server.
+
+`backend/tsconfig.json` has no `strict`, so the compiler will not catch loose types for you. Annotate parameters and return types explicitly.
+
+## 8. Review the diff
+
+Before reporting done, re-read your own diff for the two failures that pass lint and tests: a relative import missing the `.js` extension, and a contract annotation dropped at the controller boundary because inference "already works".

--- a/.cursor/skills/implement-frontend-feature/SKILL.md
+++ b/.cursor/skills/implement-frontend-feature/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: implement-frontend-feature
+description: Step-by-step workflow for adding or changing a screen, component or state slice in the Angular NGXS PWA. Use when implementing frontend UI, a new route, an NGXS slice, or an API call under frontend/src/app.
+---
+
+# Implement a frontend feature
+
+Process only. What correct frontend code looks like is defined in `.cursor/rules/angular.mdc` and `ngxs.mdc` — do not restate those rules, follow them.
+
+Run every command from `frontend/`. The shell is PowerShell: separate commands with `;`, never `&&`.
+
+## Checklist
+
+```
+- [ ] 1. Read a neighbouring screen
+- [ ] 2. Decide which state layer owns this
+- [ ] 3. Model, mapper and API service
+- [ ] 4. Actions and state handlers
+- [ ] 5. Component and route
+- [ ] 6. Sync impact
+- [ ] 7. Tests
+- [ ] 8. lint / test / build
+```
+
+## 1. Read a neighbouring screen
+
+`frontend/src/app/mobile-app/components/screens/mb-task-screen/` is the fullest example: component, template, SCSS and a screen-scoped state in one folder.
+
+`mobile-app/` is the live shell. `desktop-app/` exists but is not routed from `main.ts` — do not add features there unless asked explicitly.
+
+## 2. Decide which state layer owns this
+
+Three layers, and picking wrong is the usual mistake:
+
+| Layer | Where | Owns |
+|-------|-------|------|
+| Screen state | next to the screen, registered on the route with `provideStates([...])` | form values, view mode, UI orchestration |
+| Domain state | `shared/state/` (`tasks`, `user`, `sync`, `app`), registered in `main.ts` | entities, optimistic updates, enqueuing sync changes |
+| Component signal | inside the component | local UI only — never domain data |
+
+Screen state orchestrates and dispatches into domain state; it does not own entities. `MbTaskScreenState.handleCreateTask` dispatching `TasksAction.CreateTask` is the pattern.
+
+Every slice is persisted to the device (`withNgxsStoragePlugin({ keys: '*' })`), so treat any new state field as a stored-data shape change: keep it serializable, and make defaults and selectors tolerate state written by an older build.
+
+## 3. Model, mapper and API service
+
+For data crossing the network:
+
+1. Wire types come from `@brainassistant/contracts`. Need a new one? Follow `change-contract`, rebuild included.
+2. Frontend model in `shared/models/<name>.model.ts` — a `type`, reusing enums from contracts.
+3. Mapper in `shared/mappers/<name>.mapper.ts` for DTO ↔ model. DTOs must not leak into state.
+4. Endpoint constant in `shared/constants/api-endpoints.const.ts`.
+5. API service in `shared/services/api/<name>.service.ts`, typed with the contract namespace.
+
+Do not add DTOs to `shared/dto/` — it only re-exports from contracts for legacy reasons.
+
+## 4. Actions and state handlers
+
+Actions go in a namespace with a `[Scope] Human readable` type string, in `*.action.ts` or `*.actions.ts` — follow the neighbouring file, both spellings exist.
+
+Slices talk by dispatching actions, never by injecting each other. A global slice handling a screen's action is the preferred direction.
+
+## 5. Component and route
+
+Standalone component with its own `imports`. Add the route in `mobile-app/mobile-app.routing.ts`, with `providers: [provideStates([...])]` if it has screen state.
+
+Add `data-test` attributes to anything E2E will need to click or read, while you are in the template — retrofitting them later is what makes E2E specs reach for CSS classes.
+
+## 6. Sync impact
+
+If the feature creates, updates or deletes a synced entity, the domain state must update optimistically **and** dispatch `SyncAction.ChangeForSyncOccurred`. Read `shared/state/tasks.state.ts` for the shape.
+
+Then check the receiving side: inbound server changes are applied in the same slice via `SyncAction.ServerChangesLoaded`. A new entity type needs both directions plus a backend endpoint — see `implement-fullstack-feature`.
+
+## 7. Tests
+
+State logic gets a Jest spec in `frontend/tests/unit/state/<slice>.spec.ts`, using `TestBed` with `provideStore([...])` and `store.reset({...})`. Follow `tasks.state.spec.ts`.
+
+A user-visible flow gets a Playwright spec — follow `add-e2e-test`.
+
+## 8. Verify
+
+```powershell
+npm run lint:check
+npm run lint:style
+npm test
+npm run build-prod
+```
+
+E2E is a separate, slower loop (`npm run e2e`); run it when you touched a flow that specs cover.

--- a/.cursor/skills/implement-fullstack-feature/SKILL.md
+++ b/.cursor/skills/implement-fullstack-feature/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: implement-fullstack-feature
+description: End-to-end workflow for a feature spanning contracts, backend and the Angular PWA, including the offline sync protocol on both sides. Use when a task requires a new synced entity, a new API plus UI, or any change crossing more than one package.
+---
+
+# Implement a full-stack feature
+
+The orchestration skill. It sequences the others; it does not repeat them.
+
+- Backend detail → `implement-backend-feature`
+- Frontend detail → `implement-frontend-feature`
+- Contract detail → `change-contract`
+- Schema detail → `change-mongodb-schema`
+
+Three packages, and each is a separate npm project: run commands inside `contracts/`, `backend/` or `frontend/`, never from the repo root. PowerShell — chain with `;`, never `&&`.
+
+## Why the order matters
+
+The apps compile against `contracts/dist/`. Starting in the backend or the frontend means writing code against a type that does not exist yet, so work outside-in from the contract. And because the frontend is an offline PWA, "done" is not "it works on my machine after a hard refresh" — it is "an old cached client still works".
+
+## Checklist
+
+```
+- [ ] 1. Trace the existing vertical slice
+- [ ] 2. Decide the contract and compatibility
+- [ ] 3. contracts/ + rebuild
+- [ ] 4. Backend
+- [ ] 5. Backend integration test
+- [ ] 6. Frontend data layer
+- [ ] 7. Sync, both directions
+- [ ] 8. Frontend UI
+- [ ] 9. Frontend tests
+- [ ] 10. Full verification
+- [ ] 11. Report compatibility
+```
+
+## 1. Trace the existing vertical slice
+
+Read the create-task path end to end before writing anything. It is the template for any synced feature:
+
+```
+MbTaskScreenState.handleCreateTask
+  -> TasksAction.CreateTask                (optimistic insert in shared/state/tasks.state.ts)
+  -> SyncAction.ChangeForSyncOccurred      (queued in shared/state/sync.state.ts)
+  -> ClientChangesService.send             (POST /api/sync/task)
+  -> CreateTaskController -> CreateTask -> TaskRepoService -> TaskModel
+  -> SyncAction.LocalChangeWasSynchronized (dequeued)
+```
+
+Name the files your feature will need at each hop before starting. If a hop has no equivalent in your feature, say why.
+
+## 2. Decide the contract and compatibility
+
+Write down the request and response shape, and whether the change is additive or breaking for clients running an old cached build with old persisted state. Decide this now — it constrains every later step.
+
+## 3. `contracts/` and rebuild
+
+Add DTOs, enums and the endpoint namespace, export from `src/index.ts`, then:
+
+```powershell
+cd contracts; npm run build
+```
+
+## 4. Backend
+
+Use-case folder, repo, route. If a new entity is stored, the Mongoose schema and `IDbModels` registration happen here. Changing an existing schema is a separate decision — go through `change-mongodb-schema`.
+
+## 5. Backend integration test
+
+Write it now, not at the end. It pins the real status codes and payloads that the frontend E2E mocks must mirror; doing it later means the mocks encode a guess.
+
+## 6. Frontend data layer
+
+Model, mapper, endpoint constant, API service. Bottom-up, so the state slice has something to call.
+
+## 7. Sync, both directions
+
+Both halves are required, and the inbound one is the half that gets forgotten:
+
+- **Outbound** — the domain state updates optimistically and dispatches `SyncAction.ChangeForSyncOccurred`; `ClientChangesService` must know the path for the new entity.
+- **Inbound** — the slice handles `SyncAction.ServerChangesLoaded` and merges server changes; the backend get-changes flow must include the new entity.
+
+A new synced entity also touches `EChangedEntity` in contracts.
+
+## 8. Frontend UI
+
+Component, route, `data-test` hooks.
+
+## 9. Frontend tests
+
+State spec in `frontend/tests/unit/state/`, and an E2E spec for the user-visible flow with mocks extended in `e2e/utils/api-mocks.util.ts` to match what step 5 pinned.
+
+## 10. Full verification
+
+```powershell
+cd contracts; npm run build; npm test
+cd ../backend; npm run lint:check; npm run typecheck; npm test
+cd ../frontend; npm run lint:check; npm run lint:style; npm test; npm run build-prod
+cd ../frontend; npm run e2e
+```
+
+## 11. Report compatibility
+
+Close by stating what happens to a client that is still running the previous build with previously persisted state, and to documents already in MongoDB. If either breaks, say so plainly rather than burying it.

--- a/.cursor/skills/review-changes/SKILL.md
+++ b/.cursor/skills/review-changes/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: review-changes
+description: Workflow for reviewing a diff in this repo against its architecture, offline-compatibility and testing conventions. Use when asked to review changes, check a branch before a PR, or verify work just completed.
+---
+
+# Review changes
+
+Process only. The standards themselves live in `.cursor/rules/` — this skill is the order to check them in and the failures that are specific to this repo.
+
+## Checklist
+
+```
+- [ ] 1. Get the diff and its scope
+- [ ] 2. Compatibility first
+- [ ] 3. Layering
+- [ ] 4. Repo-specific traps
+- [ ] 5. Tests
+- [ ] 6. Run the checks
+- [ ] 7. Report by severity
+```
+
+## 1. Get the diff and its scope
+
+```powershell
+git status; git diff; git diff --stat main...HEAD
+```
+
+First question: does the diff match what was asked? Flag drive-by renames, unrelated refactors and reformatted files as scope problems even when the code is fine.
+
+Note which packages are touched — `contracts/`, `backend/`, `frontend/` — because that decides which of the following sections apply.
+
+## 2. Compatibility first
+
+The highest-cost mistakes in this repo are invisible to the compiler and to the tests.
+
+- **Contracts.** Any change to `contracts/src` that renames a field, makes an optional field required, removes anything, or changes the meaning of an enum value is breaking for clients running cached builds. Was it flagged as such? Was `contracts` rebuilt so both apps actually see it?
+- **MongoDB.** There are no migrations. A changed or removed field means existing documents no longer match. Does the diff say what happens to them?
+- **Persisted state.** NGXS persists every slice (`keys: '*'`). New or renamed state fields meet state written by an older build — do defaults and selectors tolerate that?
+- **Secrets.** No hard-coded URLs, credentials or keys; no logging of passwords, tokens or whole request bodies.
+
+## 3. Layering
+
+Backend, per `backend-architecture.mdc` and `mongodb.mdc`: use cases free of Express types, no Mongoose model reached directly outside a repo, no raw document escaping a repo, errors returned as `Result` rather than thrown, no new layer invented next to the use-case folders, validation in the domain via `Guard` rather than a new library.
+
+Frontend, per `angular.mdc` and `ngxs.mdc`: no `HttpClient` in a component, domain data in NGXS rather than component signals, slices communicating by dispatching rather than injecting each other, DTOs mapped to models instead of stored raw, manual subscriptions torn down.
+
+Queries: every query returning a collection needs an explicit bound; no filtering or sorting in JavaScript that MongoDB could do; no query inside a loop.
+
+## 4. Repo-specific traps
+
+These pass lint and tests and still break things:
+
+- A relative import in `backend/` missing the `.js` extension — it compiles and fails at runtime.
+- A `FooContract.Request` / `FooContract.Response` annotation deleted from a controller as "redundant". It documents the public API; it stays.
+- A `type` converted to `interface` (or back) for consistency. House style: `type` for shapes, `interface` for contracts a class implements.
+- A new mocked unit test for a controller, use case or repo. This project tests those through integration.
+- E2E mocks that no longer mirror the backend's real status codes and bodies.
+- `page.waitForTimeout()` in a Playwright spec, or `data-testid` instead of `data-test`.
+- Backend types left loose because `tsconfig` has no `strict` to catch them.
+
+## 5. Tests
+
+Does the changed behaviour have coverage in the right place — integration in `backend/test/integration/` for a backend flow, a state spec in `frontend/tests/unit/state/` for state logic, a Playwright spec for a user-visible flow? Unit tests in `backend/test/unit/` are only for pure domain models and mappers.
+
+Check the assertions, not just the presence of a spec: an integration test that never reads the document back through the model has not tested persistence.
+
+## 6. Run the checks
+
+Only for packages the diff touches:
+
+```powershell
+cd contracts; npm run build; npm test
+cd ../backend; npm run lint:check; npm run typecheck; npm test
+cd ../frontend; npm run lint:check; npm run lint:style; npm test; npm run build-prod
+```
+
+## 7. Report by severity
+
+Group findings so the author knows what blocks a merge:
+
+- **Blocking** — breaks behaviour, breaks old clients or stored data, leaks secrets, violates an architecture rule.
+- **Should fix** — missing coverage, loose types, an unbounded query that will grow.
+- **Optional** — naming and readability.
+
+Point at the file and line and say what to do instead. If the diff is clean, say so plainly rather than manufacturing findings.

--- a/.cursor/skills/write-integration-test/SKILL.md
+++ b/.cursor/skills/write-integration-test/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: write-integration-test
+description: Workflow for writing a backend integration spec against the real Express app and in-memory MongoDB. Use when adding or updating tests under backend/test, or after implementing a backend use case that needs coverage.
+---
+
+# Write a backend integration test
+
+Process only. Testing policy is in `.cursor/rules/testing-backend.mdc` — follow it, do not restate it.
+
+Integration is the default here: the real `createApp()`, real routers, real Passport JWT, real repos, real mappers, real Mongoose, against `mongodb-memory-server`. Only external systems get mocked. Do not unit-test a controller or use case with a mocked repo.
+
+Run from `backend/`. PowerShell — chain with `;`.
+
+## Checklist
+
+```
+- [ ] 1. Place and name the spec
+- [ ] 2. Copy the lifecycle
+- [ ] 3. Authenticate
+- [ ] 4. Happy path
+- [ ] 5. Validation failure
+- [ ] 6. External-service failure
+- [ ] 7. Run it, then run it alone
+```
+
+## 1. Place and name the spec
+
+`backend/test/integration/<module>/` mirrors `src/modules/<module>/usecases/`. Name the file `<use-case>.int.spec.ts` and describe it after the layers it exercises:
+
+```ts
+describe('Integration: CreateTask (Controller -> UseCase -> Repo -> MongoDB)', () => {
+```
+
+Imports carry the `.js` extension like the rest of the backend.
+
+## 2. Copy the lifecycle
+
+Do not invent a parallel mini-Express or fake `req.user`. The harness in `test/integration/_setup/` exists for this:
+
+```ts
+beforeAll(async () => {
+  await startInMemoryMongo();
+  app = buildTestApp().app;
+}, 30_000);
+
+afterAll(async () => {
+  await stopInMemoryMongo();
+});
+
+beforeEach(async () => {
+  await clearDatabase();
+  jest.clearAllMocks();
+});
+```
+
+The 30-second timeout on `beforeAll` matters: the first run downloads a MongoDB binary.
+
+## 3. Authenticate
+
+`seedTestUser()` creates a real user and returns `{ userId, email, jwtCookie }`. Send requests through `authenticatedRequest(app, jwtCookie)`, which sets the `jwt` cookie on `get` / `post` / `patch` / `delete`.
+
+Everything under `/api/sync` sits behind `isAuthenticated`. For a flow that logs in as part of the test, `jwtCookieFromResponse(res)` extracts the cookie from a login response.
+
+Other helpers in `_setup/`: `sync.helper.ts`, `slack.helper.ts`, `fake-google.strategy.ts`. Read them before writing your own — and read `harness.smoke.spec.ts` for the minimal working example.
+
+## 4. Happy path
+
+Assert observable outcomes, not internals:
+
+1. the HTTP status,
+2. the response body, typed against the DTO from `@brainassistant/contracts`,
+3. the document read back through the Mongoose model.
+
+The third assertion is the one that makes this an integration test — without it you have only checked the controller's echo.
+
+## 5. Validation failure
+
+Send input the domain rejects and assert the status **and** the body's `name` and `message`. `name` carries the domain error code, and the E2E mocks on the frontend mirror these responses, so getting them exactly right matters beyond this spec.
+
+## 6. External-service failure
+
+Mock only external systems: Slack, Google Drive, OpenAI, email. Google Drive is already stubbed for Jest in `test/__mocks__/google-drive-services.ts` so the ESM `mime` package never loads. Repos, mappers, domain models and the database stay real.
+
+Assert that the use case degrades the way it is designed to — whether the external failure fails the request or is swallowed.
+
+## 7. Run it
+
+```powershell
+npm test -- <spec-file>
+npm test
+```
+
+Run the single spec first, then the whole suite: a spec that passes alone but fails in the suite is leaking state, which usually means a missed `clearDatabase()` or a module-level mock that is not reset.
+
+Specs must be deterministic — no real network, no assertions on the current time or random values, no ordering assumptions. Remove any `console.log` before finishing.


### PR DESCRIPTION
## Summary
- Add nine project Cursor skills under `.cursor/skills/` for recurring workflows: backend/frontend/fullstack features, contract and MongoDB schema changes, integration/E2E tests, sync debugging, and change review.
- Skills document process and decision order only; architecture and style stay in existing `.cursor/rules/` so the layers do not duplicate each other.
- Cover repo-specific traps agents miss (rebuild `contracts/dist`, no Mongo migrations, offline NGXS persistence, sync push-loop stop-on-first-error).

## Test plan
- [ ] Open Cursor agent chat and confirm the new skills appear under project skills
- [ ] Ask for a backend feature and verify `implement-backend-feature` is applied
- [ ] Ask about a stuck sync queue and verify `debug-sync-issue` is applied
- [ ] Spot-check that skill commands match `backend/`, `frontend/`, and `contracts/` package scripts