### PR TITLE
chore: add AGENTS.md with canonical code references

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -14,6 +14,8 @@ alwaysApply: true
 
 `frontend`, `backend` and `contracts` are separate npm packages. Run `npm`/`ng` commands from inside the relevant folder, not from the repo root.
 
+Each of the three has an `AGENTS.md` describing its layout, the canonical code to imitate for each kind of task, and the code that must not be copied. Read the one for the package you are touching before writing code in it.
+
 ## Shell
 
 The dev environment is Windows PowerShell. Do not chain commands with `&&` and do not use bash-only syntax; use `;` or separate commands.

--- a/.cursor/skills/add-e2e-test/SKILL.md
+++ b/.cursor/skills/add-e2e-test/SKILL.md
@@ -21,7 +21,7 @@ Specs drive the real UI on the `e2e` build configuration against a fully mocked 
 
 ## 1. Read the existing specs
 
-`frontend/e2e/create-task.spec.ts` is the fullest flow; `edit-task`, `delete-task` and `sync-error` cover the variants. `frontend/e2e/README.md` describes the setup.
+`frontend/AGENTS.md` names the spec to imitate and what to take from it; `frontend/e2e/README.md` describes the setup and what each existing spec covers.
 
 Reuse `e2e/utils/task-flow.util.ts` before writing new navigation: `signIn(page)` and `createTaskWithTitle(page, title)` already handle the sign-in and create flows including their waits. Most specs need a task to exist but are not testing creation.
 

--- a/.cursor/skills/change-contract/SKILL.md
+++ b/.cursor/skills/change-contract/SKILL.md
@@ -5,7 +5,7 @@ description: Workflow for editing the shared @brainassistant/contracts package -
 
 # Change a shared contract
 
-Process only. Layout and compatibility rules are in `.cursor/rules/contracts.mdc` — follow them, do not restate them.
+Process only. Layout and compatibility rules are in `.cursor/rules/contracts.mdc` — follow them, do not restate them. `contracts/AGENTS.md` maps the package and names the contract namespace to imitate.
 
 `contracts/` is a separate npm package linked into both apps as `file:../contracts`, and **the apps import compiled `dist/`**. A source-only edit changes nothing until it is rebuilt. This is the step that gets forgotten and produces confusing "the type is right there" errors.
 

--- a/.cursor/skills/implement-backend-feature/SKILL.md
+++ b/.cursor/skills/implement-backend-feature/SKILL.md
@@ -24,7 +24,7 @@ Run every command from `backend/`. The shell is PowerShell: separate commands wi
 
 ## 1. Read a neighbouring use case first
 
-Open `backend/src/modules/sync/usecases/task/create/` and read all five files. It is the reference shape: `create-task.controller.ts`, `create-task.usecase.ts`, `create-task.errors.ts`, `create-task.mapper.ts`, `index.ts`.
+`backend/AGENTS.md` names the canonical reference for each kind of endpoint — write, read, external service, binary response — and the modules that must not be used as a template. Open the one that matches what you are building and read every file in that folder before writing any code.
 
 If the feature is close to an existing flow, mirror that flow instead of the reference. Naming varies slightly between modules (a few use `_index.ts`) — match the neighbours you are joining, not this document.
 

--- a/.cursor/skills/implement-frontend-feature/SKILL.md
+++ b/.cursor/skills/implement-frontend-feature/SKILL.md
@@ -24,7 +24,7 @@ Run every command from `frontend/`. The shell is PowerShell: separate commands w
 
 ## 1. Read a neighbouring screen
 
-`frontend/src/app/mobile-app/components/screens/mb-task-screen/` is the fullest example: component, template, SCSS and a screen-scoped state in one folder.
+`frontend/AGENTS.md` names the canonical reference for each kind of work — a screen with its own state, a self-contained feature, a synced entity, an API service, a device abstraction — plus the code that must not be copied. Open the matching one and read the whole folder first.
 
 `mobile-app/` is the live shell. `desktop-app/` exists but is not routed from `main.ts` — do not add features there unless asked explicitly.
 

--- a/.cursor/skills/write-integration-test/SKILL.md
+++ b/.cursor/skills/write-integration-test/SKILL.md
@@ -5,7 +5,7 @@ description: Workflow for writing a backend integration spec against the real Ex
 
 # Write a backend integration test
 
-Process only. Testing policy is in `.cursor/rules/testing-backend.mdc` — follow it, do not restate it.
+Process only. Testing policy is in `.cursor/rules/testing-backend.mdc` — follow it, do not restate it. The spec to imitate is named in `backend/AGENTS.md`; every helper is mapped in `backend/test/README.md`.
 
 Integration is the default here: the real `createApp()`, real routers, real Passport JWT, real repos, real mappers, real Mongoose, against `mongodb-memory-server`. Only external systems get mocked. Do not unit-test a controller or use case with a mocked repo.
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,120 @@
+# Backend
+
+Express + Mongoose API. ESM (`"type": "module"`), use-case architecture, no DI container, no
+central error middleware. Entry points: `server.ts` → `src/app.ts` → `src/create-app.ts`.
+
+The conventions this code must follow are in `.cursor/rules/backend-architecture.mdc`,
+`mongodb.mdc`, `backend-domain-values.mdc` and `typescript-type-vs-interface.mdc`. The workflow for
+adding a feature is `.cursor/skills/implement-backend-feature/`. This file is neither: it says where
+things live and which existing code to imitate.
+
+Run every command from `backend/`. PowerShell — separate commands with `;`, never `&&`. There is no
+`build` script: `npm run typecheck` is the compile check, `npm run compile` starts the server.
+
+## Where things are
+
+```
+src/
+├── config/                 env-backed configuration
+├── loaders/                mongoose, ngrok
+├── modules/<module>/
+│   ├── routers/            HTTP wiring only
+│   ├── services/           module-local services
+│   └── usecases/<name>/    controller + usecase + errors + mapper + index
+└── shared/
+    ├── core/               Result, Guard, UseCase, UseCaseError, serviceFail
+    ├── domain/             Entity, ValueObject, models/, values/
+    ├── infra/              auth (Passport), database/mongodb, http, integrations
+    ├── mappers/            toDomain / toPersistence / toDTO per entity
+    ├── repo/               the only place Mongoose models are touched
+    └── services/, types/, utils/
+```
+
+Modules: `auth`, `sync`, `files`, `ai`, `integrations` (`google`, `slack`). Routes are mounted in
+`src/shared/infra/http/api/index.ts`; everything under `/api/sync`, `/api/files` and `/api/ai` sits
+behind `isAuthenticated`.
+
+Tests live in `test/` and have their own guide in `test/README.md`.
+
+## Canonical references
+
+Production code to open and imitate when building something of the same kind. These are examples of
+shape, not of business logic — copy the structure, never the domain rules.
+
+### Write endpoint on the sync protocol → `src/modules/sync/usecases/task/create/`
+
+The complete five-file use-case folder, and the default template for a new endpoint. Shows the
+contract type at the HTTP boundary (`SendChangeContract.Request<TaskDTO>`), request mapping split
+into `create-task.mapper.ts`, validation delegated to `Task.create` returning a `Result`, an error
+namespace whose members carry `httpCode`, repos injected through the constructor, and `index.ts` as
+the single composition root that instantiates everything and exports the controller.
+
+Do not copy the commented-out Slack block and its `TODO` / `TICKET` comments at the end of
+`create-task.usecase.ts`.
+
+### Read endpoint → `src/modules/sync/usecases/get-changes/`
+
+The reference for a query-string request and for keeping the contract visible on the way out:
+`const response: GetChangesContract.Response = ...` before `this.ok(res, response)`. Also shows
+`requestToUsecaseParams` and `usecaseResultToResponse` as private controller methods, which is the
+right home for mapping too small to deserve its own file.
+
+Do not copy the class name `GetChnagesController`. The typo is not the convention.
+
+### Use case wrapping an external service → `src/modules/ai/usecases/speech-to-text/`
+
+How a third-party failure becomes a typed use-case error: the service returns a `Result`, the use
+case switches on `error.code` and re-wraps it into its own `SpeechToTextErrors` rather than letting
+the provider's error escape. Also the case where a local `*.dto.ts` is legitimate — a multipart
+audio upload with no shared contract.
+
+### Binary response → `src/modules/files/usecases/get-image/`
+
+A controller that answers with bytes instead of JSON: `res.writeHead(200, file.headers)` and
+`file.data.pipe(res)` on success, the usual `jsonResponse` on failure. Reference for the response
+half only — see the note on `upload-image` below before copying the request half.
+
+### Webhook with signature verification → `src/modules/integrations/slack/`
+
+Router-level middleware (`verification-challenge.function.ts`) in front of the controller, plus a
+module that owns its own enums and DTO for a payload that never reaches the frontend.
+
+### Domain validation → `src/shared/domain/models/task.ts`, `src/shared/domain/values/user/user-email.ts`
+
+Where input validation lives in this project: a `create()` factory, `Guard`, a `Result` return and an
+error enum. There is no validation library and no layer above the domain that does this.
+
+### Persistence pair → `src/shared/repo/task-repo.service.ts` + `src/shared/mappers/task.mapper.ts`
+
+A repo resolving models from the injected `models` registry, and the mapper that keeps raw documents
+from escaping it.
+
+### Integration spec → `test/integration/sync/task-create.int.spec.ts`
+
+What a finished spec looks like: the in-memory Mongo lifecycle, `seedTestUser()` +
+`authenticatedRequest()`, and three cases — unauthenticated `401`, the happy path, and a rejected
+DTO asserted on status plus `name` and `message`. The happy path is the one to imitate closely: it
+checks the response body against the contract DTO **and** reads the document back through
+`models.TaskModel`, which is what separates an integration test from a controller echo.
+
+`test/integration/_setup/harness.smoke.spec.ts` is the smaller starting point, and `test/README.md`
+maps every helper.
+
+## Not references
+
+Existing code that works but must not be used as a template.
+
+- **`src/modules/auth/usecases/`** — the oldest module. It predates `@brainassistant/contracts` and
+  still carries local `*.dto.ts` files, and one folder is named `sing-up`. Extending an auth flow in
+  place is fine; starting a new module from it is not.
+- **Misspelled names already in the tree** — `delete-task.erros.ts`,
+  `slack-event-recieved.errors.ts`, `GetChnagesController`, `sing-up/`, and the live route
+  `/api/integrations/slack/event-recived`. They stay as they are: renaming touches imports, and the
+  Slack path is registered with a third party. Never reproduce the spellings in new files.
+- **`src/modules/integrations/google/usecases/get-oauth-consent-screen/`** — a controller with no use
+  case behind it. Acceptable for a pure redirect, misleading as a shape to copy.
+- **`src/modules/files/usecases/upload-image/`** — the flow works, but `execute()` takes a second
+  `user` argument that is not part of `UploadImageParams`, which breaks the single-params `UseCase`
+  signature; limits sit in local constants marked `TODO: move to config`; and a failed Google Drive
+  call is reported through `console.error`. Read it to understand image upload; do not take its
+  shape as the pattern.

--- a/contracts/AGENTS.md
+++ b/contracts/AGENTS.md
@@ -1,0 +1,68 @@
+# Contracts
+
+`@brainassistant/contracts` — the single source of truth for the HTTP boundary between `frontend` and
+`backend`. Both apps link it as `file:../contracts` and **import the compiled `dist/`**, so a change
+in `src/` is invisible until `npm run build` runs here.
+
+The conventions are in `.cursor/rules/contracts.mdc`; the workflow is
+`.cursor/skills/change-contract/`. This file says where things live and what to imitate.
+
+Types only: no validation, no mappers, no runtime logic, no dependencies. The one runtime export is
+`PUBLIC_API_SHAPE`, which exists for the shape test.
+
+```powershell
+npm run build          # required before either app sees a change
+npm test               # rebuilds, then diffs the public API against test/public-api.shape.json
+```
+
+## Where things are
+
+```
+src/
+├── dto/        api-response, auth, change, tag, task, user  (+ index barrel)
+├── enums/      change-action, changed-entity, task-status, task-type  (+ index barrel)
+├── contracts/  send-change, get-changes, files  (+ index barrel)
+├── public-api.shape.ts   compile-time key lists + the snapshot payload
+└── index.ts    the public surface — anything missing here does not exist for the apps
+test/
+├── public-api.shape.json   committed snapshot
+└── public-api.shape.test.cjs
+```
+
+DTOs are re-exported from `src/index.ts` with `export type`, enums with a value `export`.
+
+## Canonical references
+
+### Endpoint namespace → `src/contracts/send-change.contract.ts`
+
+The reference shape: one namespace per endpoint holding `Request` and `Response` as `type`, generic
+over the entity DTO (`Request<T extends ChangeableObjectDTO>`), with a doc comment naming the actual
+HTTP methods and paths it covers and spelling out the compatibility reasoning — why the response
+returns the saved entity and why a cached PWA that ignores the body stays compatible. That last part
+is the habit worth copying: this package is a public API, so the reasoning belongs next to the type.
+
+`src/contracts/get-changes.contract.ts` is the same shape without the generic.
+
+### Wire enum → `src/enums/changed-entity.enum.ts`
+
+A small enum with explicit string values. Values are part of the wire format and of already-persisted
+client state: add members, never repurpose or renumber existing ones.
+
+### Guarding the public API → `src/public-api.shape.ts` + `test/public-api.shape.json`
+
+How a breaking change is caught here rather than in production. Each DTO declares its keys with
+`satisfies readonly (keyof T)[]` and an `ExactKeys` check, so removing or renaming a field fails
+`tsc` first; then the exported `PUBLIC_API_SHAPE` is diffed against the committed JSON snapshot, so
+the change also has to be acknowledged deliberately by updating the snapshot.
+
+Every new DTO, enum or contract namespace gets an entry here. A snapshot updated without a sentence
+explaining why is the thing to catch in review.
+
+## Not references
+
+- **`src/contracts/files.contract.ts`** — the contract itself is fine and in use, but it declares
+  `export interface Request` where house style calls for a `type` for payload shapes, and its
+  indentation is broken. Copy `send-change.contract.ts` instead.
+- **`README.md`** — written for an earlier layout. It lists `send-change.dto.ts`,
+  `get-changes.dto.ts` and `file.dto.ts` under `src/dto/`, none of which exist, and does not mention
+  `src/enums/` or `src/contracts/` at all. Trust `src/` and this file over it.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,115 @@
+# Frontend
+
+Angular 19 PWA: standalone components, NGXS state, offline-first with a change queue, packaged for
+Android through Capacitor. Bootstrapped in `src/main.ts` — there are no NgModules.
+
+The conventions this code must follow are in `.cursor/rules/angular.mdc` and `ngxs.mdc`; the
+workflow for adding a feature is `.cursor/skills/implement-frontend-feature/`. This file is neither:
+it says where things live and which existing code to imitate.
+
+Run every command from `frontend/`. PowerShell — separate commands with `;`, never `&&`.
+
+## Where things are
+
+```
+src/app/
+├── mobile-app/             the live shell — routes come from mobile-app.routing.ts
+│   └── components/
+│       ├── common/         reusable pieces of the mobile UI
+│       └── screens/        one folder per screen: component + template + scss + state
+├── desktop-app/            present but NOT routed from main.ts
+└── shared/
+    ├── components/         redirects/, ui-elements/
+    ├── features/           self-contained features (api + components + state + facade)
+    ├── state/              global slices: app, user, tasks, sync
+    ├── services/           api/, application/, auth/, infrastructure/, integrations/,
+    │                       pwa/, utility/, adapters/, device-detector/
+    ├── models/ mappers/    domain models and DTO ↔ model conversion
+    ├── constants/          api-endpoints.const.ts
+    └── dto/ forms/ pipes/ helpers/
+```
+
+`main.ts` registers exactly four global slices — `AppState`, `UserState`, `SyncState`, `TasksState` —
+and `withNgxsStoragePlugin({ keys: '*' })`, so every slice, including screen and feature slices, is
+persisted on the device.
+
+Tests: state specs in `tests/unit/state/`, mocked Playwright specs in `e2e/` (guide in
+`e2e/README.md`), live two-client specs in `e2e-live/`.
+
+## Canonical references
+
+Existing code to open and imitate when building something of the same kind. Copy the structure, not
+the business logic.
+
+### Self-contained feature → `src/app/shared/features/voice-input/`
+
+The newest architecture in this app and the template for a feature that could later be lifted out:
+`api/`, `components/`, `state/` and a facade in one folder. Shows a feature-scoped NGXS slice holding
+only process status, workflow orchestration inside action handlers, `inject()` throughout, errors
+surfaced by dispatching `AppAction.ShowErrorInUI`, and — in `voice-recording.facade.ts` — the
+boundary that keeps the feature from depending on device infrastructure directly.
+
+Two parts of it are not exemplary: `components/voice-input-trigger/` subscribes to dialog outputs
+without `takeUntilDestroyed()`, and `api/speech-to-text.service.ts` declares its own response type
+and builds the URL inline instead of using `@brainassistant/contracts` and `api-endpoints.const.ts`.
+Follow the API-service reference below for that half.
+
+### Screen with a screen-scoped slice → `src/app/mobile-app/components/screens/mb-task-screen/`
+
+The fullest screen: component, template, SCSS, sub-components, `*.actions.ts` and `*.state.ts` in one
+folder, registered on the route with `provideStates([...])`. Shows the intended division of labour —
+the screen slice owns view mode and form data, reads other slices through `selectSnapshot`, and
+dispatches `TasksAction.*` instead of writing entities itself, then resets to defaults on close.
+
+### Synced entity, both directions → `src/app/shared/state/tasks.state.ts`
+
+The template for any entity that syncs. Outbound: an optimistic update through
+`patch` / `append` / `updateItem` / `removeItem` followed by
+`SyncAction.ChangeForSyncOccurred`. Inbound: `@Action(SyncAction.ServerChangesLoaded)` filtering by
+`EChangedEntity` and merging with `iif(...)` for insert-or-update. Both halves are required; the
+inbound one is the half that gets forgotten.
+
+### API service → `src/app/shared/services/api/server-changes.service.ts`
+
+Endpoint from `api-endpoints.const.ts`, request and response typed with the contract namespace, and
+the DTO mapped to a model inside `pipe(map(...))` so no DTO ever reaches NGXS state.
+`client-changes.service.ts` next to it is the map of which endpoint each synced entity posts to.
+
+### Device / platform abstraction → `src/app/shared/services/pwa/voice-recorder/`
+
+An interface, a web and a native implementation selected at runtime via `Capacitor.isNativePlatform()`,
+recording strategies behind them, and a small state machine guarding invalid transitions. The shape
+to follow for anything that touches a browser or device API, so E2E can stub it.
+
+### Mapper → `src/app/shared/mappers/task.mapper.ts`
+
+Static `toModel` / `toDto` on a class, contract DTO in, plain model out.
+
+### State spec → `tests/unit/state/tasks.state.spec.ts`
+
+`TestBed` with `provideStore([...])`, `store.reset({...})` to establish the starting state,
+`firstValueFrom(store.dispatch(...))` to await a handler, and assertions taken from
+`store.selectSnapshot(...)`. Covers both directions — local create/update/delete and a merge of
+`SyncAction.ServerChangesLoaded`.
+
+### E2E spec → `e2e/create-task.spec.ts` with `e2e/utils/api-mocks.util.ts`
+
+The fullest mocked flow: `setupApiMocks(page)` first, `data-test` selectors, `page.waitForResponse`
+registered before the click that triggers it, then the outgoing payload inspected via
+`request().postDataJSON()`. `e2e/utils/task-flow.util.ts` holds the reusable sign-in and
+create-task steps; `edit-task`, `delete-task` and `sync-error` are the variants.
+
+## Not references
+
+Existing code that works but must not be used as a template.
+
+- **`src/app/shared/state/sync.state.ts`** — the sync engine. Read it to understand the protocol; do
+  not imitate it. It logs with `console.log` / `console.error`, carries several `TODO` blocks with
+  ticket links, owns a `setInterval` inside the state class, and one of its actions is misspelled in
+  both the class name and the type string (`SyncinhriniziationWasFailed`,
+  `'[Sync] Syncinhriniziation Was Failed'`). Leave the existing spelling alone unless you were asked
+  to rename it; never reproduce it in a new action.
+- **`src/app/desktop-app/`** — not reachable: `main.ts` routes `mobileRoutes` only. One of its files
+  is even named `dt-home-screencomponent.ts`. Do not add features here unless explicitly asked.
+- **`src/app/shared/dto/`** — legacy. `task.dto.ts` only re-exports `TaskDTO` from contracts, and
+  `user.dto.ts` still duplicates the shape locally. New payload types go in `contracts/`.


### PR DESCRIPTION
## Summary
- Add `backend/AGENTS.md`, `frontend/AGENTS.md`, and `contracts/AGENTS.md` with layout maps plus canonical production examples (and explicit non-examples).
- Point workflow skills at those files instead of hard-coding module paths inside process docs.

## Test plan
- [ ] Open each canonical path listed in the PR description and judge whether you would still copy it.
- [ ] Confirm anti-examples (`Not references`) match code you do not want imitated.
- [ ] Spot-check that skills now defer to AGENTS.md (`implement-backend-feature`, `implement-frontend-feature`, `add-e2e-test`, `write-integration-test`, `change-contract`).
- [ ] No app code changed; lint/tests are unchanged.

Made with [Cursor](https://cursor.com)