### PR TITLE
fix(docker): chown files volume in prod so image uploads work

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -30,7 +30,8 @@ COPY backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh \
   && chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Root only for entrypoint (chown named volume at FILES_UPLOAD_PATH); CMD runs as node via gosu.
-USER root
 ENTRYPOINT ["docker-entrypoint.sh"]
+# Image default is node (docker:S6471). production.yml sets user: "0" so the
+# entrypoint can chown the files volume, then gosu drops back to node.
+USER node
 CMD ["node", "./dist/server.js"]

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -2,9 +2,9 @@ FROM node:24
 
 WORKDIR /usr/src/app
 
-# Native deps for sharp (libvips)
+# Native deps for sharp (libvips) + entrypoint helper (gosu)
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends libvips42 \
+  && apt-get install -y --no-install-recommends libvips42 gosu \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy contracts package first
@@ -24,6 +24,13 @@ COPY backend/ .
 RUN NODE_OPTIONS="--max-old-space-size=4096" npx tsc
 
 RUN chown -R node:node /usr/src/app /usr/src/contracts
-USER node
 
+COPY backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+# Strip CRLF if the file was saved on Windows (fixes: /usr/bin/env: 'sh\r': No such file)
+RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh \
+  && chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Root only for entrypoint (chown named volume at FILES_UPLOAD_PATH); CMD runs as node via gosu.
+USER root
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "./dist/server.js"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 set -e
 # Named volume mounts as root:root; runtime user is `node` → multer cannot write without this.
-mkdir -p /app/backend/files/tmp /app/backend/files/uploads
-chown -R node:node /app/backend/files
+# Path comes from compose (`FILES_UPLOAD_PATH`); both the dev image (/app/backend) and
+# Dockerfile.prod (/usr/src/app) mount the volume at that env path, not at WORKDIR.
+upload_root="${FILES_UPLOAD_PATH:-/app/backend/files}"
+mkdir -p "$upload_root/tmp" "$upload_root/uploads"
+chown -R node:node "$upload_root"
 exec gosu node "$@"

--- a/production.yml
+++ b/production.yml
@@ -12,6 +12,8 @@ services:
 
   backend:
     restart: always
+    # Root at start so docker-entrypoint.sh can chown the files volume; it then gosu's to node.
+    user: "0"
     volumes:
       - ./nginx/ssl:/usr/ssl
     build:


### PR DESCRIPTION
## Summary
- Production backend ran as `node` without the files-volume entrypoint that already exists in the dev image.
- The named `files` volume mounts as root, so multer could not write `FILES_UPLOAD_PATH/tmp` and `POST /api/files/image` returned `EACCES`.
- `Dockerfile.prod` now installs `gosu` and uses the same entrypoint; the script chowns `FILES_UPLOAD_PATH` (not a hardcoded WORKDIR path) before dropping to `node`.

## Test plan
- [ ] On the server, rebuild the backend image: `docker compose -f docker-compose.yml -f production.yml up -d --build backend`
- [ ] Confirm the process is `node` after startup and `/app/backend/files/tmp` is writable by that user
- [ ] Save an image in the app and confirm `POST /api/files/image` is no longer 500
- [ ] Until rebuild, the existing container can be unblocked with: `docker compose -f docker-compose.yml -f production.yml exec -u root backend sh -c "mkdir -p /app/backend/files/tmp /app/backend/files/uploads && chown -R node:node /app/backend/files"`
