### PR TITLE
fix: handle infra next(err) as ServiceError without leaking paths

### DIFF
--- a/backend/src/create-app.ts
+++ b/backend/src/create-app.ts
@@ -5,6 +5,8 @@ import session from 'express-session';
 import { apiRouters } from './shared/infra/http/api/index.js';
 import UserModel from './shared/infra/database/mongodb/user.model.js';
 import { googleStrategy, jwtStrategy } from './shared/infra/auth/index.js';
+import { unexpectedErrorHandler } from './shared/infra/http/unexpected-error.middleware.js';
+import { LoggerService } from './shared/services/logger/logger.service.js';
 
 /**
  * Builds the Express app (middleware, Passport, routers) without connecting
@@ -43,6 +45,7 @@ export function createApp(): Application {
   passport.use(googleStrategy);
 
   app.use('/', apiRouters);
+  app.use(unexpectedErrorHandler(new LoggerService()));
 
   return app;
 }

--- a/backend/src/shared/core/app-error.ts
+++ b/backend/src/shared/core/app-error.ts
@@ -1,4 +1,4 @@
-export class AppError<U = string> extends Error {
+export abstract class AppError<U = string> extends Error {
   public readonly code: U;
 
   constructor(message: string, code: U, options?: ErrorOptions) {

--- a/backend/src/shared/infra/http/models/base-controller.ts
+++ b/backend/src/shared/infra/http/models/base-controller.ts
@@ -1,6 +1,11 @@
 import express from 'express';
 import { serialize } from '../utils/middleware.js';
 
+export const UNEXPECTED_ERROR_RESPONSE = {
+  name: 'UNEXPECTED_ERROR',
+  message: 'Some unexpected error occurred',
+} as const;
+
 export enum EHttpStatus {
   Ok = 200,
   Created = 201,
@@ -67,10 +72,10 @@ export abstract class BaseController {
   public fail(res: express.Response, error: Error | string): express.Response {
     // Log errors here
     console.log(error);
-    const UNEXPECTED_ERROR = 'UNEXPECTED_ERROR';
-    return res.status(EHttpStatus.InternalServerError).json({
-      name: UNEXPECTED_ERROR,
-      message: 'Some unexpected error occurred',
-    });
+    return BaseController.jsonResponse(
+      res,
+      EHttpStatus.InternalServerError,
+      UNEXPECTED_ERROR_RESPONSE,
+    );
   }
 }

--- a/backend/src/shared/infra/http/unexpected-error.middleware.ts
+++ b/backend/src/shared/infra/http/unexpected-error.middleware.ts
@@ -1,0 +1,24 @@
+import { ErrorRequestHandler } from 'express';
+import { LoggerService } from '../../services/logger/logger.service.js';
+import {
+  BaseController,
+  EHttpStatus,
+  UNEXPECTED_ERROR_RESPONSE,
+} from './models/base-controller.js';
+import { toUnexpectedInfraServiceError } from './unexpected-infra.error.js';
+
+/**
+ * Catch-all for exceptions that called `next(err)` before a controller
+ * (multer disk write, body parser, …). Not a UseCaseError bus: those stay Result values.
+ */
+export function unexpectedErrorHandler(logger: LoggerService): ErrorRequestHandler {
+  return (err: unknown, _req, res, next) => {
+    if (res.headersSent) {
+      next(err);
+      return;
+    }
+
+    logger.logServiceError(toUnexpectedInfraServiceError(err));
+    BaseController.jsonResponse(res, EHttpStatus.InternalServerError, UNEXPECTED_ERROR_RESPONSE);
+  };
+}

--- a/backend/src/shared/infra/http/unexpected-infra.error.ts
+++ b/backend/src/shared/infra/http/unexpected-infra.error.ts
@@ -1,0 +1,28 @@
+import { ServiceError } from '../../core/service-error.js';
+import { ServiceErrorLevel } from '../../core/service-error-level.enum.js';
+
+export enum UnexpectedInfraError {
+  UnexpectedFailure = 'UNEXPECTED_INFRA_ERROR__FAILURE',
+}
+
+const CRITICAL_ERRNO_CODES = new Set(['EACCES', 'EPERM', 'ENOSPC', 'EROFS']);
+
+function levelFromThrown(error: unknown): ServiceErrorLevel {
+  if (error instanceof Error && 'code' in error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code && CRITICAL_ERRNO_CODES.has(code)) {
+      return ServiceErrorLevel.Critical;
+    }
+  }
+  return ServiceErrorLevel.High;
+}
+
+/** Translate a thrown/next'd exception into the ServiceError model (HTTP adapter, not a use case). */
+export function toUnexpectedInfraServiceError(error: unknown): ServiceError<UnexpectedInfraError> {
+  return new ServiceError(
+    'Unexpected infrastructure failure',
+    UnexpectedInfraError.UnexpectedFailure,
+    error,
+    levelFromThrown(error),
+  );
+}

--- a/backend/test/integration/files/upload-image.int.spec.ts
+++ b/backend/test/integration/files/upload-image.int.spec.ts
@@ -117,4 +117,32 @@ describe('Integration: UploadImage (Controller -> UseCase -> Repo -> MongoDB)', 
     expect(res.body).toHaveProperty('message');
     expect(await models.ImageModel.findOne({ imageId: 'image-too-big' }).lean()).toBeNull();
   });
+
+  it('returns UNEXPECTED_ERROR when multer cannot write the upload temp dir', async () => {
+    const { jwtCookie } = await seedTestUser();
+    const tmpDir = path.join(process.cwd(), 'test-uploads/tmp');
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- local test fixture
+    await fsp.writeFile(tmpDir, 'not-a-directory');
+
+    try {
+      const res = await authenticatedRequest(app, jwtCookie)
+        .post('/api/files/image')
+        .field('imageId', 'image-unwritable-tmp')
+        .attach('file', TEST_IMAGE_PATH);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({
+        name: 'UNEXPECTED_ERROR',
+        message: 'Some unexpected error occurred',
+      });
+      expect(
+        await models.ImageModel.findOne({ imageId: 'image-unwritable-tmp' }).lean(),
+      ).toBeNull();
+    } finally {
+      await fsp.rm(tmpDir, { force: true });
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- local test upload fixture dir
+      await fsp.mkdir(tmpDir, { recursive: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Multer disk failures (`EACCES`, missing temp dir, …) called `next(err)` before the upload use case, and Express leaked the raw Node message (including the file path).
- App-level handler after the routers wraps the thrown error as a `ServiceError` (`UNEXPECTED_INFRA_ERROR__FAILURE`), logs it via `LoggerService.logServiceError`, and returns the same `UNEXPECTED_ERROR` body as `BaseController.fail()`.
- `FILE_TOO_LARGE` stays on the files router (endpoint contract). `AppError` is `abstract`.

## Test plan
- [ ] `npm test -- upload-image.int.spec.ts` from `backend/` (includes unwritable temp-dir case)
- [ ] Confirm an oversized upload is still `413` / `FILE_TOO_LARGE`
- [ ] Confirm a disk-write failure is `500` / `UNEXPECTED_ERROR` and does not include the filesystem path
