### PR TITLE
fix(docker): fit production builds and Mongo cache into 3GB RAM

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -23,9 +23,8 @@ COPY backend/ .
 # Default 1024 fits a 3GB VDS. Raise only when building on a bigger machine:
 #   docker compose ... build --build-arg TSC_MAX_OLD_SPACE_MB=4096 backend
 ARG TSC_MAX_OLD_SPACE_MB=1024
-RUN NODE_OPTIONS="--max-old-space-size=${TSC_MAX_OLD_SPACE_MB}" npx tsc -p tsconfig.prod.json
-
-RUN chown -R node:node /usr/src/app /usr/src/contracts
+RUN NODE_OPTIONS="--max-old-space-size=${TSC_MAX_OLD_SPACE_MB}" ./node_modules/.bin/tsc -p tsconfig.prod.json \
+  && chown -R node:node /usr/src/app /usr/src/contracts
 
 COPY backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # Strip CRLF if the file was saved on Windows (fixes: /usr/bin/env: 'sh\r': No such file)

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -20,8 +20,10 @@ RUN npm ci --verbose
 
 COPY backend/ .
 
-# tsc can exceed Node's default ~1.5GB heap on large projects / low-memory builders
-RUN NODE_OPTIONS="--max-old-space-size=4096" npx tsc
+# Default 1024 fits a 3GB VDS. Raise only when building on a bigger machine:
+#   docker compose ... build --build-arg TSC_MAX_OLD_SPACE_MB=4096 backend
+ARG TSC_MAX_OLD_SPACE_MB=1024
+RUN NODE_OPTIONS="--max-old-space-size=${TSC_MAX_OLD_SPACE_MB}" npx tsc -p tsconfig.prod.json
 
 RUN chown -R node:node /usr/src/app /usr/src/contracts
 

--- a/backend/tsconfig.prod.json
+++ b/backend/tsconfig.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["server.ts", "src/**/*.ts", "src/**/*.d.ts"]
+}

--- a/production.yml
+++ b/production.yml
@@ -9,6 +9,8 @@ services:
     - frontend_dist:/usr/src/app/dist
     environment:
       - BUILD_MODE=build-prod
+      # Cap Angular's Node heap so ng build cannot eat the whole 3GB VDS.
+      - NODE_OPTIONS=--max-old-space-size=1536
 
   backend:
     restart: always
@@ -19,10 +21,17 @@ services:
     build:
       context: .
       dockerfile: ./backend/Dockerfile.prod
+      args:
+        TSC_MAX_OLD_SPACE_MB: 1024
     environment:
       - PORT=3443
       - CRT_PATH=/usr/ssl/brainassistant.app.crt
       - KEY_PATH=/usr/ssl/brainassistant.app.key
+
+  db:
+    # Default WiredTiger cache on a 3GB host is ~512MB plus overhead. 256MB is Mongo's minimum
+    # and is enough for a personal task DB.
+    command: ["--wiredTigerCacheSizeGB", "0.25"]
 
   nginx:
     ports: !override


### PR DESCRIPTION
## Summary
- Cap backend `tsc` heap at 1024MB via build-arg and compile with `tsconfig.prod.json` (app sources only, no tests or source maps).
- Cap Angular `ng build` Node heap at 1536MB in the production compose overlay.
- Pin Mongo WiredTiger cache to 256MB so it does not take the default ~512MB plus overhead on a 3GB VDS.

## Test plan
- [ ] `npx tsc -p tsconfig.prod.json --noEmit` from `backend/` (already green locally)
- [ ] On the VDS: rebuild the backend image and recreate `db` + `backend`
- [ ] Confirm Mongo cache is ~256MB: `db.serverStatus().wiredTiger.cache['maximum bytes configured']`
- [ ] App starts; login and sync still work

Made with [Cursor](https://cursor.com)