### PR TITLE
fix(docker): import Drive types only so prod tsc fits in 1GB

### DIFF
--- a/backend/src/modules/integrations/google/services/google-drive.service.ts
+++ b/backend/src/modules/integrations/google/services/google-drive.service.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import { drive_v3, google } from 'googleapis';
+import { drive, drive_v3 } from 'googleapis/build/src/apis/drive/index.js';
 import { OAuth2Client } from 'googleapis-common';
 import { Readable } from 'stream';
 import mime from 'mime';
@@ -62,7 +62,7 @@ export class GoogleDriveService {
         version: 'v3',
         auth: this.oAuth2Client,
       };
-      const service = google.drive(options);
+      const service = drive(options);
 
       const fileMetadata = {
         name: filename,
@@ -119,7 +119,7 @@ export class GoogleDriveService {
       version: 'v3',
       auth: this.oAuth2Client,
     };
-    const driveService = google.drive(options);
+    const driveService = drive(options);
     return driveService;
   }
 }

--- a/backend/src/modules/integrations/google/services/index.ts
+++ b/backend/src/modules/integrations/google/services/index.ts
@@ -1,8 +1,7 @@
-import { google } from 'googleapis';
 import { GoogleDriveService } from './google-drive.service.js';
 import { OAuth2Client } from 'googleapis-common';
 
-const oAuth2Client: OAuth2Client = new google.auth.OAuth2(
+const oAuth2Client: OAuth2Client = new OAuth2Client(
   process.env.GOOGLE_CLIENT_ID,
   process.env.GOOGLE_CLIENT_SECRET,
   process.env.GOOGLE_OAUTH_CALLBACK,


### PR DESCRIPTION
## Summary
- Stop importing the `googleapis` barrel, which loads typings for every Google API and OOMs `tsc` at the 1024MB heap cap (exit 134) on a 3GB VDS.
- Use the Drive-only entry (`googleapis/build/src/apis/drive`) and construct `OAuth2Client` directly from `googleapis-common`.

## Test plan
- [x] `docker compose -f docker-compose.yml -f production.yml build backend` — `tsc -p tsconfig.prod.json` completes under `--max-old-space-size=1024`
- [ ] Google Drive image upload / download still works (OAuth client + Drive v3 calls)

Made with [Cursor](https://cursor.com)