### PR TITLE
fix(docker): pull images from kiushakov/braias

### DIFF
--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -3,7 +3,7 @@
 
 services:
   db:
-    image: kirushakov/braias:db
+    image: kiushakov/braias:db
     build: ./db
     container_name: ba-smoke-db
     environment:
@@ -30,7 +30,7 @@ services:
       retries: 20
 
   backend:
-    image: kirushakov/braias:backend
+    image: kiushakov/braias:backend
     build:
       context: .
       dockerfile: ./backend/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   frontend:
-    image: kirushakov/braias:frontend
+    image: kiushakov/braias:frontend
     container_name: frontend
     build:
       context: .
@@ -21,7 +21,7 @@ services:
       - nginx
 
   backend:
-    image: kirushakov/braias:backend
+    image: kiushakov/braias:backend
     container_name: backend
     build:
       context: .
@@ -73,7 +73,7 @@ services:
     restart: on-failure
 
   db:
-    image: kirushakov/braias:db
+    image: kiushakov/braias:db
     build: ./db
     container_name: db
     restart: always


### PR DESCRIPTION
## Summary
- Point compose image names at the Docker Hub account `kiushakov/braias` (not `kirushakov/braias`).
- `docker compose pull` was denied because `kirushakov/braias` is not this Hub account.

## Test plan
- [ ] Push local images: `docker push kiushakov/braias:backend` (and frontend, db)
- [ ] On the VDS: `docker compose -f docker-compose.yml -f production.yml pull`
- [ ] `docker compose -f docker-compose.yml -f production.yml up -d` starts from the pulled images