### PR TITLE
fix(docker): give prod tsc a 4GB heap

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -20,9 +20,8 @@ RUN npm ci --verbose
 
 COPY backend/ .
 
-# Default 1024 fits a 3GB VDS. Raise only when building on a bigger machine:
-#   docker compose ... build --build-arg TSC_MAX_OLD_SPACE_MB=4096 backend
-ARG TSC_MAX_OLD_SPACE_MB=1024
+# Image is built on a developer machine / CI, then pulled on the VDS.
+ARG TSC_MAX_OLD_SPACE_MB=4096
 RUN NODE_OPTIONS="--max-old-space-size=${TSC_MAX_OLD_SPACE_MB}" ./node_modules/.bin/tsc -p tsconfig.prod.json \
   && chown -R node:node /usr/src/app /usr/src/contracts
 

--- a/production.yml
+++ b/production.yml
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: ./backend/Dockerfile.prod
       args:
-        TSC_MAX_OLD_SPACE_MB: 1024
+        TSC_MAX_OLD_SPACE_MB: 4096
     environment:
       - PORT=3443
       - CRT_PATH=/usr/ssl/brainassistant.app.crt


### PR DESCRIPTION
## Summary
- Raise `TSC_MAX_OLD_SPACE_MB` from 1024 to 4096 in `backend/Dockerfile.prod` and `production.yml`.
- 1024MB OOMs the production image build (`tsc` exit 134). Images are compiled on a developer machine, then pulled on the VDS.

## Test plan
- [ ] `docker compose -f docker-compose.yml -f production.yml build backend` completes without exit 134
- [ ] `docker push kiushakov/braias:backend` and VDS `pull` + `up -d` still start `node ./dist/server.js`