### PR TITLE
fix(sync): skip write-invalid persisted tasks on GetChanges

### DIFF
--- a/.cursor/rules/backend-architecture.mdc
+++ b/.cursor/rules/backend-architecture.mdc
@@ -61,6 +61,35 @@ return this.ok(res, response);
 - Anything under `shared/domain/values/` is a `ValueObject` class (`create()` + getters), never a public interface/type alias. Infra payloads stay in infra; map them in the use-case. See `user-email.ts`.
 - Read `req.user` in the controller and pass plain values into the use-case; use-cases must not touch Express objects.
 
+## Public methods are the happy path
+
+A public method's body should read as the main scenario: query → map → return, or load → act → save. Do not inline a rare branch (skip a poison row, log-and-continue, retry-once) so that the special case *is* the method.
+
+Give that branch a name (`toDomainIfValid`, `openForceConsentScreen`) and keep `serviceFail` / session flags / metadata inside it.
+
+Collection reads (`getChanges` and similar pulls) must not fail the whole result because one persisted document fails write-time rules. `reconstitute` loads as-is; `create` / `update` keep `isValid`. If a row fails `checkWriteInvariants()`:
+
+- log with `serviceFail(..., Low, { id, userId, domainCode })` so `LoggerService` records it
+- omit the row (`null` / filter), do **not** `toDTO` it as a normal entity
+- do **not** return `Result.fail` or a `UseCaseError` — that becomes HTTP 4xx/5xx and blocks the rest of the pull
+
+`DomainError` is the detector. `ServiceError` is the incident. The code is backend-only if it never goes on the wire. A single-entity `getById` may still return the reconstituted row so an update can repair it.
+
+```ts
+// BAD — skip/log is the body of getChanges
+for (const raw of rows) {
+  const task = TaskMapper.toDomain(raw);
+  if (task.checkWriteInvariants().isFailure) {
+    void serviceFail(...);
+    continue;
+  }
+  tasks.push(task);
+}
+
+// GOOD — getChanges stays query + map; the name states the exception
+return rows.map(raw => this.toDomainIfValid(raw)).filter(task => task !== null);
+```
+
 ## Types and secrets
 
 `backend/tsconfig.json` has no `strict` or `strictNullChecks`, so the compiler will not catch loose types. Type parameters and return values explicitly and avoid `any`.

--- a/.cursor/rules/mongodb.mdc
+++ b/.cursor/rules/mongodb.mdc
@@ -18,6 +18,7 @@ alwaysApply: false
 - Every query returning a collection needs an explicit bound: a `userId` filter, a time window, or `.limit()` / pagination. The sync queries scoped by `userId` + `modifiedAt` are the pattern to follow.
 - Never load documents in order to filter, sort, count or group them in JavaScript when MongoDB can do it in the query.
 - Use `.lean()` for read-only queries whose result goes straight into a mapper.
+- A collection read may drop a document that fails **domain** write-rules after `toDomain` (see `toDomainIfValid` on `TaskRepoService.getChanges`). That is not a substitute for putting `userId` / time bounds in the Mongo query itself.
 - Project only the fields you need when reading documents that may carry large payloads.
 - No N+1: never query inside a loop over documents — use `$in` or a single aggregation.
 - Modify many documents with `updateMany` or `bulkWrite`, and prefer atomic operators (`$set`, `$inc`, `findOneAndUpdate`) over read-modify-write sequences.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -88,7 +88,9 @@ error enum. There is no validation library and no layer above the domain that do
 ### Persistence pair → `src/shared/repo/task-repo.service.ts` + `src/shared/mappers/task.mapper.ts`
 
 A repo resolving models from the injected `models` registry, and the mapper that keeps raw documents
-from escaping it.
+from escaping it. `getChanges` + `toDomainIfValid` is the shape for a collection pull: the public
+method is query → map → return; a poison document is logged with `serviceFail` and omitted, not
+turned into HTTP failure. Write-time rules stay on `Task.create` / `update`.
 
 ### Integration spec → `test/integration/sync/task-create.int.spec.ts`
 

--- a/backend/src/shared/domain/models/task.ts
+++ b/backend/src/shared/domain/models/task.ts
@@ -86,15 +86,13 @@ export class Task extends AggregateRoot<ITaskProps> {
     return Result.ok<Task, never>(task);
   }
 
-  public static reconstitute(
-    props: ITaskProps,
-    id: UniqueEntityID,
-  ): Result<Task | never, DomainError<Task, ETaskError>> {
-    const validationResult = Task.isValid(props);
-    if (validationResult.isFailure)
-      return validationResult as Result<never, DomainError<Task, ETaskError>>;
+  /** Load a persisted task as-is. Write-time rules stay on create/update; production documents may predate them. */
+  public static reconstitute(props: ITaskProps, id: UniqueEntityID): Task {
+    return new Task(props, id);
+  }
 
-    return Result.ok<Task, never>(new Task(props, id));
+  public checkWriteInvariants(): Result<void, DomainError<Task, ETaskError>> {
+    return Task.isValid(this.props);
   }
 
   public update(

--- a/backend/src/shared/mappers/task.mapper.ts
+++ b/backend/src/shared/mappers/task.mapper.ts
@@ -1,17 +1,16 @@
 import { Task, TaskPresitant } from '../domain/models/task.js';
 import { TaskDTO, ETaskStatus, ETaskType } from '@brainassistant/contracts';
 import { UniqueEntityID } from '../domain/UniqueEntityID.js';
-import { DomainError } from '../core/domain-error.js';
 
 export class TaskMapper {
-  public static toDomain(raw: TaskPresitant): Task | DomainError<Task> {
+  public static toDomain(raw: TaskPresitant): Task {
     const { userId, type, title, status, imageId, _id, createdAt, modifiedAt } = raw;
 
-    const taskOrError = Task.reconstitute(
+    return Task.reconstitute(
       {
         userId,
         type: type as ETaskType,
-        title,
+        title: title ?? '',
         status: status as ETaskStatus,
         imageId,
         createdAt,
@@ -19,12 +18,6 @@ export class TaskMapper {
       },
       new UniqueEntityID(_id),
     );
-
-    if (taskOrError.isFailure) {
-      console.log(taskOrError.error);
-    }
-
-    return taskOrError.isSuccess ? taskOrError.getValue() : null;
   }
 
   public static toPersistence(task: Task): TaskPresitant {

--- a/backend/src/shared/repo/task-repo.service.error.ts
+++ b/backend/src/shared/repo/task-repo.service.error.ts
@@ -1,0 +1,3 @@
+export enum ETaskRepoLoadError {
+  PersistedTaskInvalid = 'TASK_REPO_SERVICE_ERROR__PERSISTED_TASK_INVALID',
+}

--- a/backend/src/shared/repo/task-repo.service.ts
+++ b/backend/src/shared/repo/task-repo.service.ts
@@ -6,8 +6,10 @@ import { TaskMapper } from '../mappers/task.mapper.js';
 import { ServiceError } from '../core/service-error.js';
 import { Result } from '../core/result.js';
 import { serviceFail } from '../core/service-fail.factory.js';
+import { ServiceErrorLevel } from '../core/service-error-level.enum.js';
+import { ETaskRepoLoadError } from './task-repo.service.error.js';
 
-export { ETaskRepoServiceError };
+export { ETaskRepoServiceError, ETaskRepoLoadError };
 
 export class TaskRepoService {
   constructor(private readonly models: IDbModels) {}
@@ -53,16 +55,41 @@ export class TaskRepoService {
         ETaskRepoServiceError.UserTaskNotFound,
       );
 
-    const task = TaskMapper.toDomain(taskDocument) as Task;
+    const task = TaskMapper.toDomain(taskDocument);
     return Result.ok<Task, ServiceError<ETaskRepoServiceError>>(task);
   }
 
   public async getChanges(userId: string, syncTime: Date): Promise<Task[]> {
-    const taskModel = this.models.TaskModel;
-    const changedTasks: TaskDocument[] = await taskModel
-      .find({ userId: userId, modifiedAt: { $gte: new Date(syncTime) } })
-      .sort({ modifiedAt: 1 });
-    return changedTasks.map(t => TaskMapper.toDomain(t) as Task);
+    const changedTasks: TaskPresitant[] = await this.models.TaskModel.find({
+      userId: userId,
+      modifiedAt: { $gte: new Date(syncTime) },
+    })
+      .sort({ modifiedAt: 1 })
+      .lean();
+
+    return changedTasks.map(raw => this.toDomainIfValid(raw)).filter(task => task !== null);
+  }
+
+  private toDomainIfValid(raw: TaskPresitant): Task | null {
+    const task = TaskMapper.toDomain(raw);
+    const invariants = task.checkWriteInvariants();
+    if (invariants.isSuccess) {
+      return task;
+    }
+
+    void serviceFail<ETaskRepoLoadError>(
+      'Persisted task failed write-time validation and was skipped',
+      ETaskRepoLoadError.PersistedTaskInvalid,
+      {
+        level: ServiceErrorLevel.Low,
+        metadata: {
+          taskId: task.id.toString(),
+          userId: task.userId,
+          domainCode: invariants.error.code,
+        },
+      },
+    );
+    return null;
   }
 
   public async deleteTaskById(taskId: string): Promise<void> {

--- a/backend/test/integration/sync/get-changes.int.spec.ts
+++ b/backend/test/integration/sync/get-changes.int.spec.ts
@@ -1,7 +1,17 @@
 import { Application } from 'express';
 import request from 'supertest';
-import { EChangeAction, EChangedEntity, GetChangesContract } from '@brainassistant/contracts';
+import {
+  EChangeAction,
+  EChangedEntity,
+  ETaskStatus,
+  ETaskType,
+  GetChangesContract,
+} from '@brainassistant/contracts';
 import { EGetChangesUseCaseError } from '../../../src/modules/sync/usecases/get-changes/get-changes.errors.js';
+import { models } from '../../../src/shared/infra/database/mongodb/index.js';
+import { ServiceErrorLevel } from '../../../src/shared/core/service-error-level.enum.js';
+import { ETaskError } from '../../../src/shared/domain/models/task.js';
+import { ETaskRepoLoadError } from '../../../src/shared/repo/task-repo.service.js';
 import { authenticatedRequest, seedTestUser } from '../_setup/auth.helper.js';
 import { buildTestApp } from '../_setup/build-test-app.js';
 import { clearDatabase, startInMemoryMongo, stopInMemoryMongo } from '../_setup/mongo-memory.js';
@@ -89,6 +99,55 @@ describe('Integration: GetChanges (Controller -> UseCase -> Repo -> MongoDB)', (
         object: expect.objectContaining({ id: created.id }),
       }),
     ]);
+  });
+
+  it('skips a persisted task that fails write-time validation instead of 500', async () => {
+    const { userId, jwtCookie } = await seedTestUser();
+    const clientId = await allocateClientId(app, jwtCookie);
+    const validTask = await createTaskViaApi(app, jwtCookie, {
+      id: 'task-valid-alongside-legacy',
+      title: 'Still delivered with the legacy row',
+    });
+
+    await models.TaskModel.create({
+      _id: 'legacy-empty-title',
+      userId,
+      type: ETaskType.Basic,
+      title: '',
+      status: ETaskStatus.Todo,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      modifiedAt: new Date('2024-01-02T00:00:00.000Z'),
+    });
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      const res = await fetchChanges(app, jwtCookie, clientId);
+      expect(res.status).toBe(200);
+
+      const body: GetChangesContract.Response = res.body;
+      expect(body.changes).toEqual([
+        expect.objectContaining({
+          entity: EChangedEntity.Task,
+          action: EChangeAction.Updated,
+          object: expect.objectContaining({ id: validTask.id, title: validTask.title }),
+        }),
+      ]);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        `[SERVICE ERROR] ${ETaskRepoLoadError.PersistedTaskInvalid}: Persisted task failed write-time validation and was skipped`,
+        expect.objectContaining({
+          level: ServiceErrorLevel.Low,
+          metadata: {
+            taskId: 'legacy-empty-title',
+            userId,
+            domainCode: ETaskError.TitleMissed,
+          },
+        }),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/backend/test/unit/domain/task.spec.ts
+++ b/backend/test/unit/domain/task.spec.ts
@@ -111,4 +111,30 @@ describe('Task', () => {
       expect(updateResult.error.code).toBe(ETaskError.TitleMissed);
     });
   });
+
+  describe('reconstitute', () => {
+    it('loads a persisted task that create() would reject', () => {
+      const createdAt = new Date('2024-01-01T00:00:00.000Z');
+      const modifiedAt = new Date('2024-01-02T00:00:00.000Z');
+
+      const task = Task.reconstitute(
+        {
+          ...baseTaskProps,
+          title: '',
+          createdAt,
+          modifiedAt,
+        },
+        new UniqueEntityID('legacy-task'),
+      );
+
+      expect(task.id.toString()).toBe('legacy-task');
+      expect(task.title).toBe('');
+      expect(task.createdAt).toEqual(createdAt);
+      expect(task.modifiedAt).toEqual(modifiedAt);
+
+      const invariants = task.checkWriteInvariants();
+      expect(invariants.isFailure).toBe(true);
+      expect(invariants.error.code).toBe(ETaskError.TitleMissed);
+    });
+  });
 });

--- a/backend/test/unit/mappers/task.mapper.spec.ts
+++ b/backend/test/unit/mappers/task.mapper.spec.ts
@@ -48,10 +48,28 @@ describe('TaskMapper', () => {
         modifiedAt,
       };
 
-      const domain = TaskMapper.toDomain(raw) as Task;
+      const domain = TaskMapper.toDomain(raw);
 
       expect(domain.createdAt).toEqual(createdAt);
       expect(domain.modifiedAt).toEqual(modifiedAt);
+    });
+
+    it('loads a persisted task with an empty title and no imageId', () => {
+      const raw: TaskPresitant = {
+        _id: 'legacy-task',
+        userId: 'user-1',
+        type: ETaskType.Basic,
+        title: '',
+        status: ETaskStatus.Todo,
+        createdAt: new Date('2024-06-01T10:00:00.000Z'),
+        modifiedAt: new Date('2024-06-02T15:30:00.000Z'),
+      };
+
+      const domain = TaskMapper.toDomain(raw);
+      const dto = TaskMapper.toDTO(domain);
+
+      expect(dto.id).toBe('legacy-task');
+      expect(dto.title).toBe('');
     });
   });
 
@@ -93,7 +111,7 @@ describe('TaskMapper', () => {
       ).getValue();
 
       const persisted = TaskMapper.toPersistence(original);
-      const restored = TaskMapper.toDomain(persisted) as Task;
+      const restored = TaskMapper.toDomain(persisted);
 
       expect(restored.id.toString()).toBe('task-123');
       expect(restored.title).toBe('Valid task title');


### PR DESCRIPTION
## Summary
- Stop GetChanges from 500ing when a persisted task fails write-time rules (empty title and no image).
- Load those rows with `reconstitute`, log a Low `ServiceError` via `serviceFail`, and omit them from the pull. `create` / `update` still reject invalid titles.
- Document the happy-path collection-read shape in backend architecture / Mongo rules.

## Test plan
- [ ] GetChanges with a mix of a valid task and a Mongo row `{ title: "", no imageId }` returns 200 and only the valid task.
- [ ] Logs `[SERVICE ERROR] TASK_REPO_SERVICE_ERROR__PERSISTED_TASK_INVALID` at Low with `taskId`, `userId`, and `domainCode: TitleMissed`.
- [ ] Creating/updating a task with an empty title and no image is still rejected.
- [ ] A valid Drive/sync pull of normal tasks is unchanged.
