### PR TITLE
chore(ts): enable strict compiler checks

### DIFF
--- a/.cursor/rules/backend-architecture.mdc
+++ b/.cursor/rules/backend-architecture.mdc
@@ -87,11 +87,11 @@ for (const raw of rows) {
 }
 
 // GOOD — getChanges stays query + map; the name states the exception
-return rows.map(raw => this.toDomainIfValid(raw)).filter(task => task !== null);
+return rows.map(raw => this.toDomainIfValid(raw)).filter((task): task is Task => task !== null);
 ```
 
 ## Types and secrets
 
-`backend/tsconfig.json` has no `strict` or `strictNullChecks`, so the compiler will not catch loose types. Type parameters and return values explicitly and avoid `any`.
+`backend/tsconfig.json` has `strict` and `noUncheckedIndexedAccess`. Type parameters and return values explicitly; do not use `any` or non-null assertions to silence the compiler. Optional and nullable values must be narrowed. Collection `.filter(x => x !== null)` needs a type predicate (`(x): x is T => x !== null`).
 
 Never hard-code URLs, credentials or keys, and never log passwords, tokens or whole request bodies.

--- a/.cursor/skills/implement-backend-feature/SKILL.md
+++ b/.cursor/skills/implement-backend-feature/SKILL.md
@@ -74,7 +74,7 @@ npm test
 
 Narrow the test run while iterating: `npm test -- <spec-file>`. There is no `build` script — `typecheck` is the compile check, and `compile` would start the server.
 
-`backend/tsconfig.json` has no `strict`, so the compiler will not catch loose types for you. Annotate parameters and return types explicitly.
+`backend/tsconfig.json` has `strict` and `noUncheckedIndexedAccess`. Annotate parameters and return types explicitly; do not use `any` or `!` to silence the compiler.
 
 ## 8. Review the diff
 

--- a/.cursor/skills/review-changes/SKILL.md
+++ b/.cursor/skills/review-changes/SKILL.md
@@ -56,7 +56,7 @@ These pass lint and tests and still break things:
 - A new mocked unit test for a controller, use case or repo. This project tests those through integration.
 - E2E mocks that no longer mirror the backend's real status codes and bodies.
 - `page.waitForTimeout()` in a Playwright spec, or `data-testid` instead of `data-test`.
-- Backend types left loose because `tsconfig` has no `strict` to catch them.
+- Backend types left loose (`any`, unchecked `!`, `null` assigned to a non-nullable field) despite `strict` and `noUncheckedIndexedAccess` in `backend/tsconfig.json`.
 
 ## 5. Tests
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -34,6 +34,10 @@ jobs:
         working-directory: ./frontend
         run: npm ci
 
+      - name: Typecheck
+        working-directory: ./frontend
+        run: npm run typecheck
+
       - name: Run knip
         working-directory: ./frontend
         run: npm run knip

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -24,9 +24,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * eslint-plugin-node), eslint-plugin-import, eslint-plugin-boundaries.
  *
  * Notes:
- * - Rules that require tsconfig `strictNullChecks` stay off until that flag is
- *   enabled in a dedicated follow-up (would be a large type migration).
- * - `no-unsafe-*` stay off for the same reason under `npm run lint --fix`.
+ * - `backend/tsconfig.json` has `strict` and `noUncheckedIndexedAccess`.
+ * - Rules that get noisier under those flags (`no-unnecessary-condition`,
+ *   `prefer-nullish-coalescing`, `no-unsafe-*`) stay off until a dedicated lint
+ *   pass. Do not treat ESLint as a substitute for `tsc`.
  */
 /** @type {import('eslint').Linter.Config[]} */
 export default [

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -48,9 +48,13 @@
       "devDependencies": {
         "@emnapi/core": "1.11.3",
         "@emnapi/runtime": "1.11.3",
+        "@types/cookie-parser": "^1.4.10",
+        "@types/express-session": "^1.19.0",
         "@types/jest": "^29.5.12",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^22.15.21",
+        "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.2",
         "@typescript-eslint/eslint-plugin": "^8.31.0",
         "@typescript-eslint/parser": "8.31",
@@ -121,6 +125,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -674,6 +679,7 @@
       "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
@@ -685,6 +691,7 @@
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3317,6 +3324,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -3335,6 +3352,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -3351,6 +3369,16 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/express-session": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.19.0.tgz",
+      "integrity": "sha512-GbypG0bog68UbOq2tSAp7SclvCUm3ha1uDi58OPRGK1NfRvCIu7Gz0M7fTGtpNG1T9a29GpuurQj9zEcT/lMXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -3428,6 +3456,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -3447,6 +3486,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/multer": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.11.tgz",
@@ -3460,6 +3506,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
       "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3498,6 +3545,17 @@
         "@types/express": "*",
         "@types/passport": "*",
         "@types/passport-oauth2": "*"
+      }
+    },
+    "node_modules/@types/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
       }
     },
     "node_modules/@types/passport-local": {
@@ -3708,6 +3766,7 @@
       "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.31.0",
         "@typescript-eslint/types": "8.31.0",
@@ -4208,6 +4267,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4488,7 +4548,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4931,6 +4990,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.20",
         "caniuse-lite": "^1.0.30001810",
@@ -5491,7 +5551,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
       "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "peer": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -5937,6 +5996,7 @@
       "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6014,6 +6074,7 @@
       "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6180,6 +6241,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8699,6 +8761,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9313,6 +9376,7 @@
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9542,6 +9606,7 @@
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9668,7 +9733,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "peer": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
@@ -10897,7 +10961,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -11038,6 +11101,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12449,6 +12513,7 @@
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12591,6 +12656,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12836,6 +12902,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12925,6 +12992,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.4"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -56,9 +56,13 @@
   "devDependencies": {
     "@emnapi/core": "1.11.3",
     "@emnapi/runtime": "1.11.3",
+    "@types/cookie-parser": "^1.4.10",
+    "@types/express-session": "^1.19.0",
     "@types/jest": "^29.5.12",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^22.15.21",
+    "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^8.31.0",
     "@typescript-eslint/parser": "8.31",

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -2,12 +2,13 @@ import * as dotenv from 'dotenv';
 import https from 'https';
 import fs from 'fs';
 import { app } from './src/app.js';
+import { requiredEnv } from './src/config/index.js';
 
 dotenv.config();
 
 const port = process.env.PORT;
-const crtPath = process.env.CRT_PATH;
-const keyPath = process.env.KEY_PATH;
+const crtPath = requiredEnv('CRT_PATH');
+const keyPath = requiredEnv('KEY_PATH');
 const caBandlePath = process.env.CA_BANDLE_PATH;
 
 const httpsOptions: https.ServerOptions = {

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -3,17 +3,23 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+export function requiredEnv(name: string): string {
+  // Fixed allowlist of required env names — not user-controlled keys.
+  // eslint-disable-next-line security/detect-object-injection
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required env variable: ${name}`);
+  }
+  return value;
+}
+
 const REQUIRED_ENV_VARS = ['FILES_UPLOAD_PATH'];
 
 REQUIRED_ENV_VARS.forEach(name => {
-  // Fixed allowlist of required env names — not user-controlled keys.
-  // eslint-disable-next-line security/detect-object-injection
-  if (!process.env[name]) {
-    throw new Error(`Missing required env variable: ${name}`);
-  }
+  requiredEnv(name);
 });
 
-const baseUploadPath = process.env.FILES_UPLOAD_PATH;
+const baseUploadPath = requiredEnv('FILES_UPLOAD_PATH');
 
 export const config = {
   paths: {

--- a/backend/src/create-app.ts
+++ b/backend/src/create-app.ts
@@ -7,6 +7,7 @@ import UserModel from './shared/infra/database/mongodb/user.model.js';
 import { googleStrategy, jwtStrategy } from './shared/infra/auth/index.js';
 import { unexpectedErrorHandler } from './shared/infra/http/utils/unexpected-error.middleware.js';
 import { LoggerService } from './shared/services/logger/logger.service.js';
+import { requiredEnv } from './config/index.js';
 
 /**
  * Builds the Express app (middleware, Passport, routers) without connecting
@@ -18,7 +19,7 @@ export function createApp(): Application {
   app.disable('x-powered-by');
   app.use(express.json());
 
-  const secret = process.env.SESSION_SECRET;
+  const secret = requiredEnv('SESSION_SECRET');
   app.use(
     session({
       secret,
@@ -32,8 +33,8 @@ export function createApp(): Application {
   if (process.env.AUTHENTICATION_STRATEGY === 'SESSION') {
     app.use(passport.initialize());
     app.use(passport.session());
-    passport.serializeUser(UserModel.serializeUser());
-    passport.deserializeUser(UserModel.deserializeUser());
+    passport.serializeUser(UserModel.serializeUser() as never);
+    passport.deserializeUser(UserModel.deserializeUser() as never);
   }
 
   if (process.env.AUTHENTICATION_STRATEGY === 'JWT') {

--- a/backend/src/loaders/mongoose.ts
+++ b/backend/src/loaders/mongoose.ts
@@ -7,7 +7,7 @@ const DB_PASSWORD = process.env.DB_PASSWORD;
 
 const DB_URI = `mongodb://${DB_USER}:${DB_PASSWORD}@${DB_CONTAINER}:${DB_PORT}/ba?authSource=admin`;
 
-export function connectToDb(client): Promise<Mongoose> {
+export function connectToDb(client: string): Promise<Mongoose> {
   return new Promise<Mongoose>((resolve, reject) => {
     mongoose
       .connect(DB_URI)

--- a/backend/src/modules/ai/services/open-ai-speech-transcriber.service.ts
+++ b/backend/src/modules/ai/services/open-ai-speech-transcriber.service.ts
@@ -168,7 +168,7 @@ export class OpenAISpeechTranscriberService {
     }
   }
 
-  private mapOpenAIErrorToLevel(error: Error): ServiceErrorLevel {
+  private mapOpenAIErrorToLevel(error: unknown): ServiceErrorLevel {
     const criticalErrorStatuses = [401, 403, 429];
     if (error instanceof OpenAI.APIError && criticalErrorStatuses.includes(error.status)) {
       return ServiceErrorLevel.High;

--- a/backend/src/modules/ai/usecases/speech-to-text/speech-to-text.controller.ts
+++ b/backend/src/modules/ai/usecases/speech-to-text/speech-to-text.controller.ts
@@ -15,6 +15,10 @@ export class SpeechToTextController extends BaseController {
 
   protected async executeImpl(req: Request, res: Response): Promise<void> {
     const file = req.file;
+    if (!file) {
+      this.fail(res, 'Audio file is required');
+      return;
+    }
     const audioBuffer = file.buffer;
     const mimeType = file.mimetype;
     const audio = new Blob([audioBuffer], { type: mimeType });

--- a/backend/src/modules/auth/services/email/adapters/mailgun.adapter.ts
+++ b/backend/src/modules/auth/services/email/adapters/mailgun.adapter.ts
@@ -1,5 +1,6 @@
 import { IMailgunClient } from 'mailgun.js/Interfaces';
 import { IMailAdapter } from '../mail-adapter.interface.js';
+import { requiredEnv } from '../../../../../config/index.js';
 
 export class MailgunAdapter implements IMailAdapter {
   private provider: IMailgunClient;
@@ -11,7 +12,7 @@ export class MailgunAdapter implements IMailAdapter {
   public async sendEmail(to: string, from: string, subject: string, html: string): Promise<void> {
     try {
       // 👇 Create email with MailGun API (provider is  MailgunClient)
-      const result = await this.provider.messages.create(process.env.EMAIL_DOMAIN, {
+      const result = await this.provider.messages.create(requiredEnv('EMAIL_DOMAIN'), {
         from: from,
         to: [to],
         subject: subject,

--- a/backend/src/modules/auth/services/email/adapters/sendgrid.adapter.ts
+++ b/backend/src/modules/auth/services/email/adapters/sendgrid.adapter.ts
@@ -21,7 +21,7 @@ export class SendgridMailAdapter implements IMailAdapter {
     } catch (error) {
       // TODO: log error here
       const response = (error as { response?: { body?: unknown } }).response;
-      if (response.body !== undefined) {
+      if (response?.body !== undefined) {
         console.error(response.body);
       }
     }

--- a/backend/src/modules/auth/services/email/mail-adapter.interface.ts
+++ b/backend/src/modules/auth/services/email/mail-adapter.interface.ts
@@ -1,3 +1,3 @@
 export interface IMailAdapter {
-  sendEmail: (to, from, subject, html) => Promise<void>;
+  sendEmail: (to: string, from: string, subject: string, html: string) => Promise<void>;
 }

--- a/backend/src/modules/auth/services/email/providers/mailgun.provider.ts
+++ b/backend/src/modules/auth/services/email/providers/mailgun.provider.ts
@@ -1,11 +1,12 @@
 import FormData from 'form-data';
 import Mailgun from 'mailgun.js';
+import { requiredEnv } from '../../../../../config/index.js';
 
 const mailgun = new Mailgun(FormData);
 
 const mailgunProvider = mailgun.client({
   username: 'api',
-  key: process.env.MAILGUN_API_KEY,
+  key: requiredEnv('MAILGUN_API_KEY'),
 });
 
 export { mailgunProvider };

--- a/backend/src/modules/auth/services/email/providers/sendgrid.provider.ts
+++ b/backend/src/modules/auth/services/email/providers/sendgrid.provider.ts
@@ -1,6 +1,7 @@
 import { MailService } from '@sendgrid/mail';
+import { requiredEnv } from '../../../../../config/index.js';
 
-const sendgridApiKey = process.env.SENDGRID_API_KEY;
+const sendgridApiKey = requiredEnv('SENDGRID_API_KEY');
 const sendgridMailProvider: MailService = new MailService();
 sendgridMailProvider.setApiKey(sendgridApiKey);
 

--- a/backend/src/modules/auth/services/login.service.ts
+++ b/backend/src/modules/auth/services/login.service.ts
@@ -4,6 +4,7 @@ import { UserDto } from '../dto/user.dto.js';
 import { LoginResponseDTO } from '../usecases/login/login.dto.js';
 import { User } from '../../../shared/domain/models/user.js';
 import { UserMapper } from '../../../shared/mappers/user.mapper.js';
+import { requiredEnv } from '../../../config/index.js';
 
 export class LoginService {
   /** JWT and cookie max-age: sliding renewal extends from each successful authenticated request */
@@ -11,7 +12,7 @@ export class LoginService {
 
   public static setJwtCookie(res: Response, loginResponseDto: LoginResponseDTO): void {
     const expiresIn = LoginService.JWT_TTL_SECONDS;
-    const newToken = jwt.sign(loginResponseDto, process.env.JWT_SECRET, {
+    const newToken = jwt.sign(loginResponseDto, requiredEnv('JWT_SECRET'), {
       expiresIn,
     });
 

--- a/backend/src/modules/auth/usecases/google-auth/google-auth.controller.ts
+++ b/backend/src/modules/auth/usecases/google-auth/google-auth.controller.ts
@@ -14,6 +14,10 @@ export class GoogleAuthController extends BaseController {
   }
 
   protected async executeImpl(req: Request, res: Response, next?: NextFunction): Promise<void> {
+    if (!next) {
+      this.fail(res, 'Express next() is required');
+      return;
+    }
     try {
       const result = await this.usecase.execute({
         context: { req, res, next },
@@ -29,7 +33,7 @@ export class GoogleAuthController extends BaseController {
         });
       }
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
   }
 }

--- a/backend/src/modules/auth/usecases/google-auth/google-auth.usecase.ts
+++ b/backend/src/modules/auth/usecases/google-auth/google-auth.usecase.ts
@@ -41,9 +41,10 @@ export class GoogleAuthUsecase implements UseCase<GoogleAuthRequest, Promise<Goo
     return new Promise<GoogleAuthResult>((resolve, reject) => {
       const handleGoogleCallback = async (
         err: unknown,
-        res: GoogleProfileWithTokens,
+        res: GoogleProfileWithTokens | false,
       ): Promise<void> => {
         if (err) return resolve(GoogleAuthErrors.AuthorizationFailed());
+        if (!res) return resolve(GoogleAuthErrors.AuthorizationFailed());
 
         const profile = res.profile;
         const tokens = res.tokens;
@@ -65,15 +66,18 @@ export class GoogleAuthUsecase implements UseCase<GoogleAuthRequest, Promise<Goo
       };
 
       try {
-        this.passport.authenticate('google', (err, res: GoogleProfileWithTokens) => {
-          handleGoogleCallback(err, res).catch((callbackErr: unknown) => {
-            reject(
-              callbackErr instanceof Error
-                ? callbackErr
-                : new Error('Unknown Google auth callback error'),
-            );
-          });
-        })(request.context.req, request.context.res, request.context.next);
+        this.passport.authenticate(
+          'google',
+          (err: unknown, res: GoogleProfileWithTokens | false) => {
+            handleGoogleCallback(err, res).catch((callbackErr: unknown) => {
+              reject(
+                callbackErr instanceof Error
+                  ? callbackErr
+                  : new Error('Unknown Google auth callback error'),
+              );
+            });
+          },
+        )(request.context.req, request.context.res, request.context.next);
       } catch (err: unknown) {
         reject(err instanceof Error ? err : new Error('Unknown Google auth error'));
       }
@@ -84,7 +88,7 @@ export class GoogleAuthUsecase implements UseCase<GoogleAuthRequest, Promise<Goo
     profile: Profile,
     tokenPayload: GoogleOAuthTokenPayload,
   ): Promise<Result<User | never, UseCaseError<EGoogleAuthUseCaseError>>> {
-    let user: User;
+    let user: User | null;
     user = await this.userRepo.getUserByGoogleId(profile.id);
 
     const tokensOrError = GoogleAuthTokens.create({
@@ -107,17 +111,22 @@ export class GoogleAuthUsecase implements UseCase<GoogleAuthRequest, Promise<Goo
       return Result.ok(user);
     }
 
-    const existUser: UserDocument = await this.userRepo.getUserByUsername(profile._json.email);
+    const emailRaw = profile._json.email;
+    if (!emailRaw) {
+      return GoogleAuthErrors.AuthorizationFailed();
+    }
+
+    const existUser: UserDocument | null = await this.userRepo.getUserByUsername(emailRaw);
 
     if (existUser) {
       if (existUser.verified) {
-        return GoogleAuthErrors.EmailAlreadyInUse(profile._json.email);
+        return GoogleAuthErrors.EmailAlreadyInUse(emailRaw);
       } else {
-        await this.userRepo.removeByUsername(profile._json.email);
+        await this.userRepo.removeByUsername(emailRaw);
       }
     }
 
-    const email: UserEmail = UserEmail.create(profile._json.email).getValue();
+    const email: UserEmail = UserEmail.create(emailRaw).getValue();
 
     if (!tokens?.refreshToken) {
       return GoogleAuthErrors.RefreshTokenNotReceived();
@@ -128,8 +137,8 @@ export class GoogleAuthUsecase implements UseCase<GoogleAuthRequest, Promise<Goo
       googleId: profile.id,
       googleAccessToken: tokens.accessToken,
       googleRefreshToken: tokens.refreshToken,
-      firstName: profile._json.given_name,
-      lastName: profile._json.family_name,
+      firstName: profile._json.given_name ?? '',
+      lastName: profile._json.family_name ?? '',
       verified: true,
     }).getValue();
 

--- a/backend/src/modules/auth/usecases/login/login.controller.ts
+++ b/backend/src/modules/auth/usecases/login/login.controller.ts
@@ -14,6 +14,10 @@ export class LoginController extends BaseController {
   }
 
   protected async executeImpl(req: Request, res: Response, next?: NextFunction): Promise<void> {
+    if (!next) {
+      this.fail(res, 'Express next() is required');
+      return;
+    }
     try {
       const result = await this.loginUsecase.execute({
         context: { req, res, next },
@@ -28,7 +32,7 @@ export class LoginController extends BaseController {
         });
       }
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
   }
 }

--- a/backend/src/modules/auth/usecases/login/login.usecase.ts
+++ b/backend/src/modules/auth/usecases/login/login.usecase.ts
@@ -52,15 +52,18 @@ export class LoginUsecase implements UseCase<LoginRequest, Promise<LoginResult>>
       };
 
       try {
-        this.passport.authenticate('local', (err, userPersistent) => {
-          handleLocalCallback(err, userPersistent).catch((callbackErr: unknown) => {
-            reject(
-              callbackErr instanceof Error
-                ? callbackErr
-                : new Error('Unknown local auth callback error'),
-            );
-          });
-        })(request.context.req, request.context.res, request.context.next);
+        this.passport.authenticate(
+          'local',
+          (err: unknown, userPersistent: UserPersistent | false) => {
+            handleLocalCallback(err, userPersistent).catch((callbackErr: unknown) => {
+              reject(
+                callbackErr instanceof Error
+                  ? callbackErr
+                  : new Error('Unknown local auth callback error'),
+              );
+            });
+          },
+        )(request.context.req, request.context.res, request.context.next);
       } catch (err: unknown) {
         reject(err instanceof Error ? err : new Error('Unknown local auth error'));
       }

--- a/backend/src/modules/auth/usecases/logout/logout.controller.ts
+++ b/backend/src/modules/auth/usecases/logout/logout.controller.ts
@@ -17,7 +17,7 @@ export class LogoutController extends BaseController {
       }
       this.ok(res);
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
     return Promise.resolve();
   }

--- a/backend/src/modules/auth/usecases/verify-email/verify-email.controller.ts
+++ b/backend/src/modules/auth/usecases/verify-email/verify-email.controller.ts
@@ -29,7 +29,7 @@ export class VerifyEmailController extends BaseController {
         });
       }
     } catch (error) {
-      this.fail(res, error.toString());
+      this.fail(res, error);
     }
   }
 }

--- a/backend/src/modules/auth/usecases/verify-email/verify-email.usecase.ts
+++ b/backend/src/modules/auth/usecases/verify-email/verify-email.usecase.ts
@@ -1,7 +1,6 @@
 import { Result } from '../../../../shared/core/result.js';
 import { UseCase } from '../../../../shared/core/UseCase.js';
 import { EUserError, User } from '../../../../shared/domain/models/user.js';
-import { VerificationToken } from '../../../../shared/domain/values/user/verification-token.js';
 import { UserRepo } from '../../../../shared/repo/user.repo.js';
 import { VerifyEmailResponseDTO } from './verify-email.dto.js';
 import { UseCaseError } from '../../../../shared/core/use-case-error.js';
@@ -24,9 +23,9 @@ export class VerifyEmailUseCase implements UseCase<VerifyEmailParams, Promise<Us
   public async execute(params: VerifyEmailParams): Promise<UseCaseResult> {
     const { tokenId } = params;
 
-    const token: VerificationToken = await this.userRepo.getTokenByTokenId(tokenId);
+    const token = await this.userRepo.getTokenByTokenId(tokenId);
     if (!token) {
-      // TODO: Potentially we can handle case if token not found (throw usecase error)
+      throw new Error('Verification token not found');
     }
     // TODO: verify that token not expired (throw usecase error)
 

--- a/backend/src/modules/files/router.ts
+++ b/backend/src/modules/files/router.ts
@@ -6,11 +6,12 @@ import { MAX_IMAGE_UPLOAD_FILE_BYTES } from './config.js';
 import { BaseController } from '../../shared/infra/http/models/base-controller.js';
 import { asyncHandler } from '../../shared/core/async-handler.function.js';
 import { UploadImageErrors } from './usecases/upload-image/upload-image.errors.js';
+import { requiredEnv } from '../../config/index.js';
 
 const filesRouter: Router = Router();
 
 const uploader: multer.Multer = multer({
-  dest: process.env.FILES_UPLOAD_PATH + '/tmp/',
+  dest: `${requiredEnv('FILES_UPLOAD_PATH')}/tmp/`,
   limits: { fileSize: MAX_IMAGE_UPLOAD_FILE_BYTES },
 });
 

--- a/backend/src/modules/files/usecases/get-image/get-image.controller.ts
+++ b/backend/src/modules/files/usecases/get-image/get-image.controller.ts
@@ -23,8 +23,13 @@ export class GetImageController extends BaseController {
     }
 
     try {
+      const imageId = req.params.imageId;
+      if (!imageId) {
+        this.fail(res, 'imageId is required');
+        return;
+      }
       const getImageRequest: GetImageRequest = {
-        imageId: req.params.imageId,
+        imageId,
         user: UserMapper.toDomain(authenticatedUser),
         imageWidth,
       };

--- a/backend/src/modules/integrations/google/services/google-drive.service.ts
+++ b/backend/src/modules/integrations/google/services/google-drive.service.ts
@@ -45,7 +45,7 @@ export class GoogleDriveService {
     });
 
     const files = res.data.files;
-    if (files.length === 0) {
+    if (!files || files.length === 0) {
       this.logger.log('No files found.');
       return;
     }
@@ -87,7 +87,7 @@ export class GoogleDriveService {
       };
 
       const media = {
-        mimeType: mimeType,
+        mimeType: mimeType ?? undefined,
         body: fs.createReadStream(resolvedFilePath), // eslint-disable-line security/detect-non-literal-fs-filename -- path checked against uploadTempDir
       };
 

--- a/backend/src/modules/integrations/google/usecases/get-oauth-consent-screen/get-oauth-consent-screen.controller.ts
+++ b/backend/src/modules/integrations/google/usecases/get-oauth-consent-screen/get-oauth-consent-screen.controller.ts
@@ -11,11 +11,17 @@ export class GetOAuthConsentScreenController extends BaseController {
   }
 
   protected executeImpl(req: Request, res: Response, next?: NextFunction): Promise<void> {
+    if (!next) {
+      this.fail(res, 'Express next() is required');
+      return Promise.resolve();
+    }
     try {
       const forceConsentParam = req.query.forceConsent;
-      const forceConsentString = Array.isArray(forceConsentParam)
+      const forceConsentFirst = Array.isArray(forceConsentParam)
         ? forceConsentParam[0]
         : forceConsentParam;
+      const forceConsentString =
+        typeof forceConsentFirst === 'string' ? forceConsentFirst : undefined;
 
       const forceConsent = forceConsentString === '1' || forceConsentString === 'true';
 
@@ -32,7 +38,7 @@ export class GetOAuthConsentScreenController extends BaseController {
         ...authOptions,
       })(req, res, next);
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
     return Promise.resolve();
   }

--- a/backend/src/modules/integrations/slack/usecases/add-to-slack/add-to-slack.controller.ts
+++ b/backend/src/modules/integrations/slack/usecases/add-to-slack/add-to-slack.controller.ts
@@ -39,7 +39,7 @@ export class AddToSlackController extends BaseController {
         });
       }
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
   }
 }

--- a/backend/src/modules/integrations/slack/usecases/add-to-slack/add-to-slack.usecase.ts
+++ b/backend/src/modules/integrations/slack/usecases/add-to-slack/add-to-slack.usecase.ts
@@ -29,18 +29,26 @@ export class AddToSlackUsecase implements UseCase<AddToSlackRequest, Promise<Add
 
   public async execute(req: AddToSlackRequest): Promise<AddToSlackResponse> {
     const response: OauthV2AccessResponse = await this._webClient.oauth.v2.access({
-      client_id: process.env.SLACK_CLIENT_ID,
-      client_secret: process.env.SLACK_CLIENT_SECRET,
+      client_id: process.env.SLACK_CLIENT_ID ?? '',
+      client_secret: process.env.SLACK_CLIENT_SECRET ?? '',
       code: req.code,
       redirect_uri: 'https://brainas.net/integrations/slack/install',
     });
 
+    const accessToken = response.access_token;
+    const authedUserId = response.authed_user?.id;
+    const slackBotUserId = response.bot_user_id;
+    const teamId = response.team?.id;
+    if (!accessToken || !authedUserId || !slackBotUserId || !teamId) {
+      throw new Error('Incomplete Slack OAuth response');
+    }
+
     const slackOAuthAccessProps: ISlackOAuthAccessProps = {
       userId: req.userId,
-      accessToken: response.access_token,
-      authedUserId: response.authed_user.id,
-      slackBotUserId: response.bot_user_id,
-      teamId: response.team.id,
+      accessToken,
+      authedUserId,
+      slackBotUserId,
+      teamId,
     };
 
     const existsSlackOAuthAccess = await this._slackOAuthAccessRepo.getSlackOAuthAccessByUserId(

--- a/backend/src/modules/integrations/slack/usecases/remove-from-slack/remove-from-slack.controller.ts
+++ b/backend/src/modules/integrations/slack/usecases/remove-from-slack/remove-from-slack.controller.ts
@@ -34,7 +34,7 @@ export class RemoveFromSlackController extends BaseController {
         });
       }
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
   }
 }

--- a/backend/src/modules/integrations/slack/usecases/remove-from-slack/remove-from-slack.usecase.ts
+++ b/backend/src/modules/integrations/slack/usecases/remove-from-slack/remove-from-slack.usecase.ts
@@ -2,7 +2,6 @@ import { WebClient } from '@slack/web-api';
 import { Result } from '../../../../../shared/core/result.js';
 import { UseCase } from '../../../../../shared/core/UseCase.js';
 import { SlackOAuthAccessRepo } from '../../../../../shared/repo/slack-oauth-access.repo.js';
-import { SlackOAuthAccess } from '../../../../../shared/domain/models/slack-oauth-access.js';
 import { UseCaseError } from '../../../../../shared/core/use-case-error.js';
 import { ERemoveFromSlackUseCaseError, RemoveFromSlackErrors } from './remove-from-slack.errors.js';
 
@@ -26,8 +25,7 @@ export class RemoveFromSlackUsecase
   }
   public async execute(req: RemoveFromSlackRequest): Promise<RemoveFromSlackResponse> {
     const userId = req.userId;
-    const slackOAuthAccess: SlackOAuthAccess =
-      await this._slackOAuthAccessRepo.getSlackOAuthAccessByUserId(userId);
+    const slackOAuthAccess = await this._slackOAuthAccessRepo.getSlackOAuthAccessByUserId(userId);
 
     if (!slackOAuthAccess) {
       return RemoveFromSlackErrors.SlackOAuthAccessNotFound();

--- a/backend/src/modules/integrations/slack/usecases/slack-event-received/slack-event-received.controller.ts
+++ b/backend/src/modules/integrations/slack/usecases/slack-event-received/slack-event-received.controller.ts
@@ -32,7 +32,7 @@ export class SlackEventReceivedController extends BaseController {
         });
       }
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
   }
 }

--- a/backend/src/modules/sync/usecases/get-changes/get-changes.usecase.ts
+++ b/backend/src/modules/sync/usecases/get-changes/get-changes.usecase.ts
@@ -43,8 +43,11 @@ export class GetChanges implements UseCase<GetChangesParams, Promise<GetChangesR
       return GetChangesErrors.ClientNotFoundError(userId, clientId);
     }
 
-    const lastSyncTime: Date = client.syncTime;
-    const changedTasks: Task[] = await this.taskRepoService.getChanges(userId, lastSyncTime);
+    const lastSyncTime = client.syncTime;
+    const changedTasks: Task[] = await this.taskRepoService.getChanges(
+      userId,
+      lastSyncTime ?? new Date(0),
+    );
 
     for (const changedTask of changedTasks) {
       const taskDto: TaskDTO = TaskMapper.toDTO(changedTask);

--- a/backend/src/modules/sync/usecases/task/create/create-task.controller.ts
+++ b/backend/src/modules/sync/usecases/task/create/create-task.controller.ts
@@ -38,7 +38,7 @@ export class CreateTaskController extends BaseController {
         });
       }
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
   }
 

--- a/backend/src/modules/sync/usecases/task/create/create-task.mapper.ts
+++ b/backend/src/modules/sync/usecases/task/create/create-task.mapper.ts
@@ -7,12 +7,12 @@ export function requestToUsecaseParams(
   userId: string,
 ): CreateTaskParams {
   const taskDto: TaskDTO = payload.changeableObjectDto;
-  const { id, ...taskPropsWithoutId } = taskDto;
+  const { id, userId: _dtoUserId, ...taskPropsWithoutId } = taskDto;
 
   return {
     taskProps: {
-      userId,
       ...taskPropsWithoutId,
+      userId,
       createdAt: new Date(taskDto.createdAt),
       modifiedAt: new Date(taskDto.modifiedAt),
     },

--- a/backend/src/modules/sync/usecases/task/delete/delete-task.controller.ts
+++ b/backend/src/modules/sync/usecases/task/delete/delete-task.controller.ts
@@ -16,9 +16,14 @@ export class DeleteTaskController extends BaseController {
     const userId = loggedUser._id;
 
     try {
+      const taskId = req.params.taskId;
+      if (!taskId) {
+        this.fail(res, 'taskId is required');
+        return;
+      }
       const result = await this._useCase.execute({
         userId,
-        taskId: req.params.taskId,
+        taskId,
       });
       if (result.isSuccess) {
         this.ok(res);

--- a/backend/src/modules/sync/usecases/task/update/update-task.controller.ts
+++ b/backend/src/modules/sync/usecases/task/update/update-task.controller.ts
@@ -37,7 +37,7 @@ export class UpdateTaskController extends BaseController {
         });
       }
     } catch (err) {
-      this.fail(res, err.toString());
+      this.fail(res, err);
     }
   }
 }

--- a/backend/src/shared/core/guard.ts
+++ b/backend/src/shared/core/guard.ts
@@ -7,20 +7,14 @@ export class Guard {
     }
   }
 
-  public static notEmptyString(argument: string): boolean {
-    if (typeof argument === 'string' && argument.trim().length) {
-      return true;
-    } else {
-      return false;
-    }
+  public static notEmptyString(argument: unknown): boolean {
+    return typeof argument === 'string' && argument.trim().length > 0;
   }
 
-  public static textLengthAtLeast(text: string, minLength: number): boolean {
-    if (typeof text === 'string' && text.trim().length >= minLength) return true;
-    return false;
+  public static textLengthAtLeast(text: unknown, minLength: number): boolean {
+    return typeof text === 'string' && text.trim().length >= minLength;
   }
-  public static textLengthAtMost(text: string, maxLength: number): boolean {
-    if (typeof text === 'string' && text.trim().length <= maxLength) return true;
-    return false;
+  public static textLengthAtMost(text: unknown, maxLength: number): boolean {
+    return typeof text === 'string' && text.trim().length <= maxLength;
   }
 }

--- a/backend/src/shared/core/result.ts
+++ b/backend/src/shared/core/result.ts
@@ -1,8 +1,8 @@
 export class Result<T, E = never> {
   public isSuccess: boolean;
   public isFailure: boolean;
-  public _error: E;
-  private _value: T;
+  public _error: E | undefined;
+  private _value: T | undefined;
 
   public constructor(isSuccess: boolean, error?: E, value?: T) {
     if (isSuccess && error) {
@@ -26,15 +26,15 @@ export class Result<T, E = never> {
       throw new Error("Can't get the value of an error result. Use 'error' instead.");
     }
 
-    return this._value;
+    return this._value as T;
   }
 
   get error(): E {
-    return this._error;
+    return this._error as E;
   }
 
   public static ok<U, E = never>(value?: U): Result<U, E> {
-    return new Result<U, E>(true, null, value);
+    return new Result<U, E>(true, undefined, value);
   }
 
   public static fail<U = never, E = never>(error: E): Result<U, E> {

--- a/backend/src/shared/domain/AggregateRoot.ts
+++ b/backend/src/shared/domain/AggregateRoot.ts
@@ -31,6 +31,9 @@ export abstract class AggregateRoot<T> extends Entity<T> {
   private logDomainEventAdded(domainEvent: IDomainEvent): void {
     const thisClass = Reflect.getPrototypeOf(this);
     const domainEventClass = Reflect.getPrototypeOf(domainEvent);
+    if (!thisClass || !domainEventClass) {
+      return;
+    }
     console.info(
       `[Domain Event Created]:`,
       thisClass.constructor.name,

--- a/backend/src/shared/domain/events/DomainEvents.ts
+++ b/backend/src/shared/domain/events/DomainEvents.ts
@@ -12,8 +12,8 @@ export class DomainEvents {
     }
   }
 
-  private static findMarkedAggregateByID(id: UniqueEntityID): AggregateRoot<unknown> {
-    let found: AggregateRoot<unknown> = null;
+  private static findMarkedAggregateByID(id: UniqueEntityID): AggregateRoot<unknown> | null {
+    let found: AggregateRoot<unknown> | null = null;
     for (const aggregate of this.markedAggregates) {
       if (aggregate.id.equals(id)) {
         found = aggregate;

--- a/backend/src/shared/domain/models/client.ts
+++ b/backend/src/shared/domain/models/client.ts
@@ -4,7 +4,7 @@ import { Result } from '../../core/result.js';
 
 export interface IClientProps {
   userId: string;
-  syncTime: Date;
+  syncTime: Date | null;
 }
 
 export class Client extends AggregateRoot<IClientProps> {
@@ -16,7 +16,7 @@ export class Client extends AggregateRoot<IClientProps> {
     return this.props.userId;
   }
 
-  get syncTime(): Date {
+  get syncTime(): Date | null {
     return this.props.syncTime;
   }
 

--- a/backend/src/shared/domain/models/task.ts
+++ b/backend/src/shared/domain/models/task.ts
@@ -53,7 +53,7 @@ export class Task extends AggregateRoot<ITaskProps> {
     return this.props.status;
   }
 
-  get imageId(): string {
+  get imageId(): string | undefined {
     return this.props.imageId;
   }
 

--- a/backend/src/shared/domain/models/user.ts
+++ b/backend/src/shared/domain/models/user.ts
@@ -50,18 +50,18 @@ export class User extends AggregateRoot<UserProps> {
   }
 
   get verified(): boolean {
-    return this.props.verified;
+    return this.props.verified ?? false;
   }
 
-  get googleId(): string {
+  get googleId(): string | undefined {
     return this.props.googleId;
   }
 
-  get googleRefreshToken(): string {
+  get googleRefreshToken(): string | undefined {
     return this.props.googleRefreshToken;
   }
 
-  get googleAccessToken(): string {
+  get googleAccessToken(): string | undefined {
     return this.props.googleAccessToken;
   }
 
@@ -76,14 +76,8 @@ export class User extends AggregateRoot<UserProps> {
 
     const isNewUser = !!!id;
 
-    const defaultProps: UserProps = {
-      username: null,
-      firstName: null,
-      lastName: null,
+    const defaultProps: Partial<UserProps> = {
       verified: false,
-      googleId: null,
-      googleAccessToken: null,
-      googleRefreshToken: null,
     };
 
     props = { ...defaultProps, ...props };

--- a/backend/src/shared/domain/values/user/google-auth-tokens.ts
+++ b/backend/src/shared/domain/values/user/google-auth-tokens.ts
@@ -37,9 +37,8 @@ export class GoogleAuthTokens extends ValueObject<GoogleAuthTokensProps> {
       );
     }
 
-    const refreshToken = Guard.notEmptyString(props.refreshToken)
-      ? props.refreshToken.trim()
-      : undefined;
+    const trimmedRefresh = props.refreshToken?.trim();
+    const refreshToken = trimmedRefresh ? trimmedRefresh : undefined;
 
     return Result.ok(
       new GoogleAuthTokens({

--- a/backend/src/shared/domain/values/user/verification-token.ts
+++ b/backend/src/shared/domain/values/user/verification-token.ts
@@ -29,7 +29,7 @@ export class VerificationToken extends ValueObject<IVerificationTokenProps> {
     super(props);
   }
 
-  public static create(props?: IVerificationTokenProps): Result<VerificationToken, never> {
+  public static create(props: IVerificationTokenProps): Result<VerificationToken, never> {
     return Result.ok<VerificationToken, never>(new VerificationToken(props));
   }
 }

--- a/backend/src/shared/infra/auth/google.strategy.ts
+++ b/backend/src/shared/infra/auth/google.strategy.ts
@@ -1,4 +1,5 @@
 import { Strategy as GoogleStrategy, Profile, VerifyCallback } from 'passport-google-oauth20';
+import { requiredEnv } from '../../../config/index.js';
 
 /** Passport payload — not a domain value object. Map to GoogleAuthTokens in the use-case. */
 export type GoogleOAuthTokenPayload = {
@@ -8,9 +9,9 @@ export type GoogleOAuthTokenPayload = {
 
 export const googleStrategy = new GoogleStrategy(
   {
-    clientID: process.env.GOOGLE_CLIENT_ID,
-    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    callbackURL: process.env.GOOGLE_OAUTH_CALLBACK,
+    clientID: requiredEnv('GOOGLE_CLIENT_ID'),
+    clientSecret: requiredEnv('GOOGLE_CLIENT_SECRET'),
+    callbackURL: requiredEnv('GOOGLE_OAUTH_CALLBACK'),
   },
   function (
     accessToken: string,
@@ -26,7 +27,7 @@ export const googleStrategy = new GoogleStrategy(
         done(null, false);
       }
     } catch (err) {
-      done(err, false);
+      done(err instanceof Error ? err : new Error('Unknown Google strategy error'), false);
     }
   },
 );

--- a/backend/src/shared/infra/auth/isAuthenticated.middleware.ts
+++ b/backend/src/shared/infra/auth/isAuthenticated.middleware.ts
@@ -10,7 +10,7 @@ export function isAuthenticated(req: Request, res: Response, next: NextFunction)
 
   switch (process.env.AUTHENTICATION_STRATEGY) {
     case 'JWT':
-      passport.authenticate('jwt', { session: false }, (error, user) => {
+      passport.authenticate('jwt', { session: false }, (error: unknown, user?: Express.User) => {
         if (error || !user) {
           const RESPONSE_CODE = EHttpStatus.Unauthorized;
           const RESPONSE_ERROR_MESSAGE = 'User not authenticated';

--- a/backend/src/shared/infra/auth/jwt.strategy.ts
+++ b/backend/src/shared/infra/auth/jwt.strategy.ts
@@ -1,6 +1,7 @@
-import { Strategy as JwtStrategy } from 'passport-jwt';
+import { Strategy as JwtStrategy, VerifiedCallback } from 'passport-jwt';
 import type { Request } from 'express';
 import UserModel from '../database/mongodb/user.model.js';
+import { requiredEnv } from '../../../config/index.js';
 
 interface IJwtTokenPayload {
   user: {
@@ -26,21 +27,22 @@ const cookieExtractor = function (req: Request): string | null {
 
 const opts = {
   jwtFromRequest: cookieExtractor,
-  secretOrKey: process.env.JWT_SECRET,
+  secretOrKey: requiredEnv('JWT_SECRET'),
 };
 
-export const jwtStrategy = new JwtStrategy(opts, async function (
+export const jwtStrategy = new JwtStrategy(opts, function (
   jwtPayload: IJwtTokenPayload,
-  done,
-) {
-  try {
-    const user = await UserModel.findOne({ _id: jwtPayload.user.userId });
-    if (user) {
-      return done(null, user);
-    } else {
-      return done(null, false);
-    }
-  } catch (err) {
-    return done(err, false);
-  }
+  done: VerifiedCallback,
+): void {
+  void UserModel.findOne({ _id: jwtPayload.user.userId })
+    .then(user => {
+      if (user) {
+        done(null, user);
+      } else {
+        done(null, false);
+      }
+    })
+    .catch((err: unknown) => {
+      done(err, false);
+    });
 });

--- a/backend/src/shared/infra/database/mongodb/client.model.ts
+++ b/backend/src/shared/infra/database/mongodb/client.model.ts
@@ -3,7 +3,7 @@ import mongoose, { Document, Schema } from 'mongoose';
 export interface IClientPersistent {
   _id?: string;
   userId: string;
-  syncTime: Date;
+  syncTime: Date | null;
 }
 
 export interface ClientDocument extends Omit<IClientPersistent, '_id'>, Document<string> {}

--- a/backend/src/shared/infra/http/models/base-controller.ts
+++ b/backend/src/shared/infra/http/models/base-controller.ts
@@ -71,7 +71,7 @@ export abstract class BaseController {
     return BaseController.jsonResponse(res, EHttpStatus.Created, payload);
   }
 
-  public fail(res: express.Response, error: Error | string): express.Response {
+  public fail(res: express.Response, error: unknown): express.Response {
     // Log errors here
     console.log(error);
     return BaseController.jsonResponse(

--- a/backend/src/shared/infra/http/utils/retry-helper.function.ts
+++ b/backend/src/shared/infra/http/utils/retry-helper.function.ts
@@ -1,3 +1,22 @@
+function httpStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+  if ('status' in error && typeof error.status === 'number') {
+    return error.status;
+  }
+  if (
+    'response' in error &&
+    typeof error.response === 'object' &&
+    error.response !== null &&
+    'status' in error.response &&
+    typeof error.response.status === 'number'
+  ) {
+    return error.response.status;
+  }
+  return undefined;
+}
+
 export async function retry<T>(
   fn: () => Promise<T>,
   retries = 2,
@@ -11,8 +30,8 @@ export async function retry<T>(
       return await fn();
     } catch (error) {
       lastError = error;
-      const status = error?.status || error?.response?.status;
-      if (status !== 429 && status < 500) throw error; // non-retriable
+      const status = httpStatus(error);
+      if (status !== undefined && status !== 429 && status < 500) throw error; // non-retriable
       const waitTime = delayMs * Math.pow(backoffFactor, attempt);
       await new Promise(r => setTimeout(r, waitTime));
       attempt++;

--- a/backend/src/shared/infra/integrations/slack/slack.service.ts
+++ b/backend/src/shared/infra/integrations/slack/slack.service.ts
@@ -6,13 +6,12 @@ import {
 } from '@slack/web-api';
 import { Channel } from '@slack/web-api/dist/response/ConversationsListResponse.js';
 import { SlackOAuthAccessRepo } from '../../../repo/slack-oauth-access.repo.js';
-import { SlackOAuthAccess } from '../../../domain/models/slack-oauth-access.js';
 
 export class SlackService {
   readonly CHANNEL_NAME = 'brainasapp';
   private _slackOAuthAccessRepo: SlackOAuthAccessRepo;
-  private _webClient: WebClient;
-  private _slackAuthedUserId: string;
+  private _webClient!: WebClient;
+  private _slackAuthedUserId!: string;
 
   constructor(slackOAuthAccessRepo: SlackOAuthAccessRepo) {
     this._slackOAuthAccessRepo = slackOAuthAccessRepo;
@@ -41,8 +40,10 @@ export class SlackService {
 
   private async initWebClient(userId: string): Promise<void> {
     // getting access token from DB
-    const slackOAuthAccess: SlackOAuthAccess =
-      await this._slackOAuthAccessRepo.getSlackOAuthAccessByUserId(userId);
+    const slackOAuthAccess = await this._slackOAuthAccessRepo.getSlackOAuthAccessByUserId(userId);
+    if (!slackOAuthAccess) {
+      throw new Error(`Slack OAuth access not found for user ${userId}`);
+    }
     const slackAccessToken = slackOAuthAccess.accessToken;
     this._slackAuthedUserId = slackOAuthAccess.authedUserId;
 
@@ -52,26 +53,29 @@ export class SlackService {
   }
 
   private async createChannelIfNotExist(): Promise<string> {
-    let channel: Channel;
-
-    // trying to find a channel with 'brainasapp' name
     const result: ConversationsListResponse = await this._webClient.conversations.list();
-    channel = result.channels.find(c => c.name === this.CHANNEL_NAME);
+    let channel: Channel | undefined = result.channels?.find(c => c.name === this.CHANNEL_NAME);
     if (!channel) {
-      // if not found - create it
       const createChannelResp: ConversationsCreateResponse =
         await this._webClient.conversations.create({
           name: this.CHANNEL_NAME,
         });
       channel = createChannelResp.channel;
     } else if (!channel.is_member) {
-      // if channel exists but app bot not a member - need to join
+      const channelId = channel.id;
+      if (!channelId) {
+        throw new Error('Slack channel is missing an id');
+      }
       await this._webClient.conversations.join({
-        channel: channel.id,
+        channel: channelId,
       });
     }
 
-    return channel.id;
+    const channelId = channel?.id;
+    if (!channelId) {
+      throw new Error('Slack channel is missing an id');
+    }
+    return channelId;
   }
 
   private async addUserIfNotInChannel(channelId: string): Promise<void> {
@@ -79,7 +83,7 @@ export class SlackService {
     const membersResp: ConversationsMembersResponse = await this._webClient.conversations.members({
       channel: channelId,
     });
-    const isMemberOfChannel = membersResp.members.includes(this._slackAuthedUserId);
+    const isMemberOfChannel = membersResp.members?.includes(this._slackAuthedUserId) ?? false;
 
     // and add if not.
     if (!isMemberOfChannel) {

--- a/backend/src/shared/mappers/client.mapper.ts
+++ b/backend/src/shared/mappers/client.mapper.ts
@@ -3,7 +3,7 @@ import { IClientPersistent } from '../infra/database/mongodb/client.model.js';
 import { UniqueEntityID } from '../domain/UniqueEntityID.js';
 
 export class ClientMapper {
-  public static toDomain(raw: IClientPersistent): Client {
+  public static toDomain(raw: IClientPersistent): Client | null {
     const clientOrError = Client.create(
       {
         userId: raw.userId,

--- a/backend/src/shared/mappers/slack-oauth-access.mapper.ts
+++ b/backend/src/shared/mappers/slack-oauth-access.mapper.ts
@@ -1,4 +1,3 @@
-import { DomainError } from '../core/domain-error.js';
 import { UniqueEntityID } from '../domain/UniqueEntityID.js';
 import {
   CreateSlackOAuthAccessResult,
@@ -7,9 +6,7 @@ import {
 } from '../domain/models/slack-oauth-access.js';
 
 export class SlackOAuthAccessMapper {
-  public static toDomain(
-    raw: ISlackOAuthAccessPresitant,
-  ): SlackOAuthAccess | DomainError<SlackOAuthAccess> {
+  public static toDomain(raw: ISlackOAuthAccessPresitant): SlackOAuthAccess | null {
     const slackOAuthAccessOrError: CreateSlackOAuthAccessResult = SlackOAuthAccess.create(
       {
         userId: raw.userId,

--- a/backend/src/shared/repo/action.repo.ts
+++ b/backend/src/shared/repo/action.repo.ts
@@ -26,8 +26,8 @@ export class ActionRepo {
 
   public async getActionsOccurredSince(
     userId: string,
-    time: Date = null,
-    actionType: EActionType = null,
+    time: Date | null = null,
+    actionType: EActionType | null = null,
   ): Promise<Action[]> {
     const actionModel = this._models.ActionModel;
 

--- a/backend/src/shared/repo/client.repo.ts
+++ b/backend/src/shared/repo/client.repo.ts
@@ -24,14 +24,17 @@ export class ClientRepo {
   public async find(userId: string, clientId: string): Promise<Client> {
     const clientModel = this._models.ClientModel;
 
-    const clientDocument: ClientDocument = await clientModel.findOne({
+    const clientDocument = await clientModel.findOne({
       userId: userId,
       _id: clientId,
     });
     const found = !!clientDocument;
     if (!found) throw new Error(`Client not found for userId=${userId} and clientId=${clientId}`);
 
-    const client: Client = ClientMapper.toDomain(clientDocument);
+    const client: Client | null = ClientMapper.toDomain(clientDocument);
+    if (!client) {
+      throw new Error(`Client not found for userId=${userId} and clientId=${clientId}`);
+    }
     return client;
   }
 
@@ -44,9 +47,12 @@ export class ClientRepo {
     const filter = { _id: clientId };
     const update = { ...clientPersistent };
 
-    const updatedClient: ClientDocument = await clientModel.findOneAndUpdate(filter, update, {
+    const updatedClient = await clientModel.findOneAndUpdate(filter, update, {
       useFindAndModify: false,
     });
+    if (!updatedClient) {
+      throw new Error(`Client with id ${clientId} not found`);
+    }
 
     return updatedClient;
   }

--- a/backend/src/shared/repo/slack-oauth-access.repo.ts
+++ b/backend/src/shared/repo/slack-oauth-access.repo.ts
@@ -34,16 +34,13 @@ export class SlackOAuthAccessRepo {
 
   public async getSlackOAuthAccessByUserId(userId: string): Promise<SlackOAuthAccess | null> {
     const SlackOAuthAccessModel = this._models.SlackOAuthAccessModel;
-    const slackOAuthAccessDocument: ISlackOAuthAccessDocument = await SlackOAuthAccessModel.findOne(
-      { userId },
-    );
+    const slackOAuthAccessDocument = await SlackOAuthAccessModel.findOne({ userId });
 
     const found = !!slackOAuthAccessDocument;
     if (!found) return null;
 
-    const slackOAuthAccess: SlackOAuthAccess = SlackOAuthAccessMapper.toDomain(
-      slackOAuthAccessDocument,
-    ) as SlackOAuthAccess;
+    const slackOAuthAccess = SlackOAuthAccessMapper.toDomain(slackOAuthAccessDocument);
+    if (!slackOAuthAccess) return null;
 
     return slackOAuthAccess;
   }

--- a/backend/src/shared/repo/task-repo.service.ts
+++ b/backend/src/shared/repo/task-repo.service.ts
@@ -33,7 +33,10 @@ export class TaskRepoService {
     const filter = { _id: taskId };
     const update = { ...taskPresitant };
 
-    const updatedTask: TaskDocument = await taskModel.findOneAndUpdate(filter, update);
+    const updatedTask = await taskModel.findOneAndUpdate(filter, update);
+    if (!updatedTask) {
+      throw new Error(`Task with id ${taskId} not found`);
+    }
 
     return updatedTask;
   }
@@ -67,7 +70,9 @@ export class TaskRepoService {
       .sort({ modifiedAt: 1 })
       .lean();
 
-    return changedTasks.map(raw => this.toDomainIfValid(raw)).filter(task => task !== null);
+    return changedTasks
+      .map(raw => this.toDomainIfValid(raw))
+      .filter((task): task is Task => task !== null);
   }
 
   private toDomainIfValid(raw: TaskPresitant): Task | null {
@@ -99,13 +104,13 @@ export class TaskRepoService {
     });
   }
 
-  public async exists(taskId: string, userId: string = null): Promise<boolean> {
+  public async exists(taskId: string, userId?: string): Promise<boolean> {
     const TaskModel = this.models.TaskModel;
     const params: { _id: string; userId?: string } = { _id: taskId };
     if (userId) {
       params.userId = userId;
     }
-    const existingTask: TaskDocument = await TaskModel.findOne(params);
+    const existingTask = await TaskModel.findOne(params);
     const found = !!existingTask;
     return found;
   }

--- a/backend/src/shared/repo/user.repo.ts
+++ b/backend/src/shared/repo/user.repo.ts
@@ -4,7 +4,6 @@ import { UserEmail } from '../domain/values/user/user-email.js';
 import { UserDocument } from '../infra/database/mongodb/user.model.js';
 import { User, UserPersistent } from '../domain/models/user.js';
 import { UserMapper } from '../mappers/user.mapper.js';
-import { VerificationTokenDocument } from '../infra/database/mongodb/verification-token.model.js';
 import {
   IVerificationTokenProps,
   VerificationToken,
@@ -41,16 +40,16 @@ export class UserRepo {
     const UserModel = this._models.UserModel;
     // TODO: Do we need to convert string -> ObjectId ? or we can use string directly?
     userId = typeof userId === 'string' ? new mongoose.Types.ObjectId(userId) : userId;
-    const userDocument: UserDocument = await UserModel.findOne({ _id: userId });
+    const userDocument = await UserModel.findOne({ _id: userId });
     const found = !!userDocument;
     if (!found) throw new Error(`User with id ${String(userId)} not found`);
     const user: User = UserMapper.toDomain(userDocument);
     return user;
   }
 
-  public async getTokenByTokenId(tokenId: string): Promise<VerificationToken> {
+  public async getTokenByTokenId(tokenId: string): Promise<VerificationToken | null> {
     const VerificationTokenModel = this._models.VerificationTokenModel;
-    const tokenDocument: VerificationTokenDocument = await VerificationTokenModel.findOne({
+    const tokenDocument = await VerificationTokenModel.findOne({
       token: tokenId,
     });
 
@@ -75,25 +74,28 @@ export class UserRepo {
     const filter = { _id: userId };
     const update = { ...userPersistent };
 
-    const updatedUser: UserDocument = await UserModel.findOneAndUpdate(filter, update, {
+    const updatedUser = await UserModel.findOneAndUpdate(filter, update, {
       useFindAndModify: false,
     });
+    if (!updatedUser) {
+      throw new Error(`User with id ${user.id.toString()} not found`);
+    }
 
     return updatedUser;
   }
 
-  public async getUserByGoogleId(googleId: string): Promise<User> {
+  public async getUserByGoogleId(googleId: string): Promise<User | null> {
     const UserModel = this._models.UserModel;
     const filter = { googleId: googleId };
-    const userDocument: UserDocument = await UserModel.findOne(filter);
+    const userDocument = await UserModel.findOne(filter);
     if (!userDocument) return null;
     return UserMapper.toDomain(userDocument);
   }
 
-  public async getUserByUsername(username: string): Promise<UserDocument> {
+  public async getUserByUsername(username: string): Promise<UserDocument | null> {
     const UserModel = this._models.UserModel;
     const filter = { username: username };
-    const user: UserDocument = await UserModel.findOne(filter);
+    const user = await UserModel.findOne(filter);
     return user;
   }
 

--- a/backend/src/shared/types/probe-image-size.d.ts
+++ b/backend/src/shared/types/probe-image-size.d.ts
@@ -1,0 +1,13 @@
+declare module 'probe-image-size' {
+  import type { Readable } from 'stream';
+
+  type ProbeResult = {
+    width: number;
+    height: number;
+    mime: string;
+  };
+
+  function probe(stream: Readable): Promise<ProbeResult>;
+
+  export default probe;
+}

--- a/backend/test/integration/_setup/auth.helper.ts
+++ b/backend/test/integration/_setup/auth.helper.ts
@@ -3,6 +3,7 @@ import { Application } from 'express';
 import request, { Test } from 'supertest';
 import { LoginService } from '../../../src/modules/auth/services/login.service.js';
 import UserModel from '../../../src/shared/infra/database/mongodb/user.model.js';
+import { requiredEnv } from '../../../src/config/index.js';
 
 export type SeedTestUserOptions = {
   email?: string;
@@ -49,7 +50,7 @@ export async function seedTestUser(options: SeedTestUserOptions = {}): Promise<S
         userId,
       },
     },
-    process.env.JWT_SECRET,
+    requiredEnv('JWT_SECRET'),
     { expiresIn: LoginService.JWT_TTL_SECONDS },
   );
 

--- a/backend/test/integration/auth/google-auth.int.spec.ts
+++ b/backend/test/integration/auth/google-auth.int.spec.ts
@@ -51,6 +51,9 @@ describe('Integration: GoogleAuth (Controller -> UseCase -> Repo -> MongoDB)', (
 
     const stored = await UserModel.findOne({ username: 'new.google@example.com' });
     expect(stored).toBeTruthy();
+    if (!stored) {
+      throw new Error('expected stored Google user');
+    }
     expect(stored.verified).toBe(true);
     expect(stored.googleId).toBe('g-new-1');
     expect(stored.googleRefreshToken).toBe('google-refresh-token');
@@ -97,6 +100,9 @@ describe('Integration: GoogleAuth (Controller -> UseCase -> Repo -> MongoDB)', (
     expect(res.body.user.email).toBe('existing.google@example.com');
 
     const stored = await UserModel.findOne({ googleId: 'g-existing' });
+    if (!stored) {
+      throw new Error('expected stored Google user');
+    }
     expect(stored.googleAccessToken).toBe('second-access');
     expect(stored.googleRefreshToken).toBe('second-refresh');
     expect(await UserModel.countDocuments({ googleId: 'g-existing' })).toBe(1);

--- a/backend/test/integration/sync/task-create.int.spec.ts
+++ b/backend/test/integration/sync/task-create.int.spec.ts
@@ -69,6 +69,9 @@ describe('Integration: CreateTask (Controller -> UseCase -> Repo -> MongoDB)', (
 
     const persisted = await models.TaskModel.findById(dto.id).lean();
     expect(persisted).not.toBeNull();
+    if (!persisted) {
+      throw new Error('expected persisted task');
+    }
     expect(persisted.title).toBe(dto.title);
     expect(persisted.imageId).toBe(dto.imageId);
     expect(String(persisted.userId)).toBe(userId);

--- a/backend/test/integration/sync/task-delete.int.spec.ts
+++ b/backend/test/integration/sync/task-delete.int.spec.ts
@@ -52,6 +52,9 @@ describe('Integration: DeleteTask (Controller -> UseCase -> Repo -> MongoDB)', (
       entityId: created.id,
       type: EActionType.TaskDeleted,
     });
+    if (!action) {
+      throw new Error('expected delete action');
+    }
     expect(action.occurredAt).toBeInstanceOf(Date);
   });
 

--- a/backend/test/integration/sync/task-update.int.spec.ts
+++ b/backend/test/integration/sync/task-update.int.spec.ts
@@ -75,6 +75,9 @@ describe('Integration: UpdateTask (Controller -> UseCase -> Repo -> MongoDB)', (
       type: created.type,
       status: created.status,
     });
+    if (!persisted) {
+      throw new Error('expected persisted task');
+    }
     expect(new Date(persisted.createdAt).toISOString()).toBe(created.createdAt);
   });
 
@@ -120,6 +123,9 @@ describe('Integration: UpdateTask (Controller -> UseCase -> Repo -> MongoDB)', (
     expect(res.body).toHaveProperty('message');
 
     const persisted = await models.TaskModel.findById(created.id).lean();
+    if (!persisted) {
+      throw new Error('expected persisted task');
+    }
     expect(persisted.title).toBe('Valid task title');
   });
 });

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,6 +7,10 @@
     "sourceMap": true,
     "outDir": "dist",
     "resolveJsonModule": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "types": ["node", "jest"]
   },
   "include": ["server.ts", "jest.config.ts", "src/**/*.ts", "src/**/*.d.ts", "test/**/*.ts"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "lint:check": "ng lint",
     "lint:style": "npx stylelint 'src/**/*.scss' --fix",
     "format": "prettier --write \"src/**/*.{ts,html,scss}\"",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit",
     "knip": "knip",
     "e2e": "npx playwright test",
     "e2e:ui": "npx playwright test --ui",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "lint:check": "ng lint",
     "lint:style": "npx stylelint 'src/**/*.scss' --fix",
     "format": "prettier --write \"src/**/*.{ts,html,scss}\"",
-    "typecheck": "tsc -p tsconfig.app.json --noEmit",
+    "typecheck": "ng build --output-path dist/typecheck",
     "knip": "knip",
     "e2e": "npx playwright test",
     "e2e:ui": "npx playwright test --ui",

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -23,9 +23,9 @@ import { PwaVersionUpdateService } from './shared/services/pwa/pwa-version-updat
   imports: [RouterOutlet],
 })
 export class AppComponent implements OnInit, OnDestroy {
-  onlineEvent: Observable<Event>;
-  offlineEvent: Observable<Event>;
-  online$: Observable<boolean>;
+  onlineEvent!: Observable<Event>;
+  offlineEvent!: Observable<Event>;
+  online$!: Observable<boolean>;
   private pwaInstallDialogOpen = false;
   private appUrlOpen?: PluginListenerHandle;
 
@@ -49,7 +49,11 @@ export class AppComponent implements OnInit, OnDestroy {
     // Listen for PWA install prompt availability and show dialog automatically
     void this.initNativeDeepLinks();
     this.pwaInstallService.installPromptAvailable.subscribe(isAvailable => {
-      if (isAvailable && !this.pwaInstallDialogOpen && this.pwaInstallService.shouldShowInstallDialog()) {
+      if (
+        isAvailable &&
+        !this.pwaInstallDialogOpen &&
+        this.pwaInstallService.shouldShowInstallDialog()
+      ) {
         console.log('PWA install prompt is available, opening dialog');
         this.pwaInstallService.markDialogShownThisSession();
         this.pwaInstallDialogOpen = true;
@@ -76,7 +80,7 @@ export class AppComponent implements OnInit, OnDestroy {
       this._zone.run(() => this.navigateFromExternalUrl(url)),
     );
     try {
-      const { url } = await App.getLaunchUrl();
+      const url = (await App.getLaunchUrl())?.url;
       if (url != null && url !== '') {
         this._zone.run(() => this.navigateFromExternalUrl(url));
       }

--- a/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tile/task-tile.component.ts
+++ b/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tile/task-tile.component.ts
@@ -19,7 +19,7 @@ export class TaskTileComponent {
   readonly androidPastelHostClass =
     Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'android';
 
-  @Input() task: Task;
+  @Input() task!: Task;
   @HostListener('click') onClick() {
     this.store.dispatch(new MbTaskTileAction.Clicked(this.task.id));
   }

--- a/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tile/task-tile.component.ts
+++ b/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tile/task-tile.component.ts
@@ -29,7 +29,7 @@ export class TaskTileComponent {
   DEFAULT_IMAGE_WIDTH = 50;
 
   isLoading = signal(true);
-  calculatedImageWidth = signal<number | null>(null);
+  calculatedImageWidth = signal<number | undefined>(undefined);
 
   constructor(
     private store: Store,

--- a/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tiles-panel.component.ts
+++ b/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tiles-panel.component.ts
@@ -18,7 +18,10 @@ export class TaskTilesPanelComponent {
         tasks: [],
       };
       for (let i = k; i < tasks.length; i += this.noOfColumns) {
-        column.tasks.push(tasks[i]);
+        const task = tasks[i];
+        if (task !== undefined) {
+          column.tasks.push(task);
+        }
       }
       this.columns = [...this.columns, column];
     }

--- a/frontend/src/app/mobile-app/components/screens/mb-home-screen/mb-home-screen.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-home-screen/mb-home-screen.component.ts
@@ -31,7 +31,7 @@ export class MbHomeScreenComponent implements OnInit {
     online: AppState.online,
   });
 
-  avatarInputData: IUserAvatarInputData;
+  avatarInputData!: IUserAvatarInputData;
 
   constructor(private store: Store) {}
 

--- a/frontend/src/app/mobile-app/components/screens/mb-login-screen/mb-login-screen.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-login-screen/mb-login-screen.component.html
@@ -13,7 +13,7 @@
         formControlName="email"
         autocomplete="email"
       />
-      <mat-error *ngIf="form.get('email').invalid"> Please input correct email </mat-error>
+      <mat-error *ngIf="form.get('email')?.invalid"> Please input correct email </mat-error>
     </mat-form-field>
 
     <mat-form-field class="login-form__password" floatLabel="never">
@@ -26,7 +26,7 @@
         formControlName="password"
         autocomplete="off"
       />
-      <mat-error *ngIf="form.get('password').invalid">
+      <mat-error *ngIf="form.get('password')?.invalid">
         Please input password, not less than 8 symbols
       </mat-error>
     </mat-form-field>

--- a/frontend/src/app/mobile-app/components/screens/mb-login-screen/mb-login-screen.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-login-screen/mb-login-screen.component.ts
@@ -22,7 +22,7 @@ import { ReactiveFormsModule } from '@angular/forms';
   ],
 })
 export class MbLoginScreenComponent implements OnInit {
-  authError: Signal<string> = this.store.selectSignal(MbLoginScreenState.authError);
+  authError: Signal<string | null> = this.store.selectSignal(MbLoginScreenState.authError);
 
   public form: UntypedFormGroup = new UntypedFormGroup({
     email: new UntypedFormControl('', [Validators.required, Validators.email]),

--- a/frontend/src/app/mobile-app/components/screens/mb-login-screen/mb-login-screen.state.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-login-screen/mb-login-screen.state.ts
@@ -4,7 +4,7 @@ import { MbLoginScreenAction } from './mb-login-screen.actions';
 import { UserAction } from 'src/app/shared/state/user.actions';
 
 interface IMbLoginScreenStateModel {
-  authErrMessage: string;
+  authErrMessage: string | null;
 }
 
 @State<IMbLoginScreenStateModel>({
@@ -14,12 +14,12 @@ interface IMbLoginScreenStateModel {
 @Injectable()
 export class MbLoginScreenState {
   @Selector()
-  static authError(state: IMbLoginScreenStateModel): string {
+  static authError(state: IMbLoginScreenStateModel): string | null {
     return state.authErrMessage;
   }
 
   @Action(UserAction.AuthFailed)
-  authFailed(ctx: StateContext<IMbLoginScreenStateModel>, { message }) {
+  authFailed(ctx: StateContext<IMbLoginScreenStateModel>, { message }: UserAction.AuthFailed) {
     ctx.patchState({
       authErrMessage: message,
     });

--- a/frontend/src/app/mobile-app/components/screens/mb-profile-screen/integrations/mb-integrations.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-profile-screen/integrations/mb-integrations.component.ts
@@ -17,7 +17,7 @@ export class MbIntegrationsComponent {
     return this.config.styleClass;
   }
   @Input() config: IMbIntegrationsComponentConfig = { styleClass: 'default' };
-  isAddedToSlack: Signal<boolean> = this._store.selectSignal(UserState.isAddedToSlack);
+  isAddedToSlack: Signal<boolean | undefined> = this._store.selectSignal(UserState.isAddedToSlack);
 
   constructor(private _store: Store) {}
   removeFromSlack() {

--- a/frontend/src/app/mobile-app/components/screens/mb-signup-screen/mb-signup-screen.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-signup-screen/mb-signup-screen.component.html
@@ -13,11 +13,11 @@
             placeholder="First Name"
             formControlName="firstName"
           />
-          <mat-error *ngIf="form.get('email').invalid"> First Name required </mat-error>
+          <mat-error *ngIf="form.get('firstName')?.invalid"> First Name required </mat-error>
         </mat-form-field>
         <mat-form-field class="login-form__email" floatLabel="never">
           <input id="lastNameInput" matInput placeholder="Last Name" formControlName="lastName" />
-          <mat-error *ngIf="form.get('email').invalid"> Last Name required </mat-error>
+          <mat-error *ngIf="form.get('lastName')?.invalid"> Last Name required </mat-error>
         </mat-form-field>
       </div>
 
@@ -29,7 +29,7 @@
           formControlName="email"
           autocomplete="email"
         />
-        <mat-error *ngIf="form.get('email').invalid"> Please input correct email </mat-error>
+        <mat-error *ngIf="form.get('email')?.invalid"> Please input correct email </mat-error>
       </mat-form-field>
 
       <mat-form-field class="login-form__password" floatLabel="never">
@@ -41,7 +41,7 @@
           formControlName="password"
           autocomplete="off"
         />
-        <mat-error *ngIf="form.get('password').invalid">
+        <mat-error *ngIf="form.get('password')?.invalid">
           Please input password, not less than 8 symbols
         </mat-error>
       </mat-form-field>
@@ -58,11 +58,11 @@
   <div class="login-link-holder">
     <div class="login-link" id="login-link" (click)="onLoginLinkClick()">Login</div>
   </div>
-} @else {
+} @else if (signUpResult(); as result) {
   <div class="mb-signup__success-block">
-    Hi, {{ signUpResult().firstName }} {{ signUpResult().lastName }}!
+    Hi, {{ result.firstName }} {{ result.lastName }}!
     <br />
     The verification link was sent on <br />
-    {{ signUpResult().email }}
+    {{ result.email }}
   </div>
 }

--- a/frontend/src/app/mobile-app/components/screens/mb-signup-screen/mb-signup-screen.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-signup-screen/mb-signup-screen.component.ts
@@ -21,7 +21,7 @@ import { MatInputModule } from '@angular/material/input';
   imports: [CommonModule, MatInputModule, ReactiveFormsModule],
 })
 export class MbSignupScreenComponent {
-  signUpResult: Signal<SignUpResponseDTO> = this.store.selectSignal(
+  signUpResult: Signal<SignUpResponseDTO | null> = this.store.selectSignal(
     MbSignupScreenState.signUpResult,
   );
 

--- a/frontend/src/app/mobile-app/components/screens/mb-signup-screen/mb-signup-screen.state.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-signup-screen/mb-signup-screen.state.ts
@@ -10,7 +10,7 @@ import { EMPTY, catchError, tap } from 'rxjs';
 import { AppAction } from 'src/app/shared/state/app.actions';
 
 export interface IMbSignupScreenStateModel {
-  signUpResult: SignUpResponseDTO;
+  signUpResult: SignUpResponseDTO | null;
 }
 
 @State<IMbSignupScreenStateModel>({
@@ -24,7 +24,7 @@ export class MbSignupScreenState {
   constructor(private authService: AuthService) {}
 
   @Selector()
-  static signUpResult(state: IMbSignupScreenStateModel): SignUpResponseDTO {
+  static signUpResult(state: IMbSignupScreenStateModel): SignUpResponseDTO | null {
     return state.signUpResult;
   }
 

--- a/frontend/src/app/mobile-app/components/screens/mb-sync-screen/mb-sync-screen.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-sync-screen/mb-sync-screen.component.html
@@ -18,7 +18,7 @@
             placeholder="Password"
             formControlName="password"
           />
-          <mat-error *ngIf="syncForm.get('password').invalid">
+          <mat-error *ngIf="syncForm.get('password')?.invalid">
             Please input correct password
           </mat-error>
         </mat-form-field>

--- a/frontend/src/app/mobile-app/components/screens/mb-sync-screen/mb-sync-screen.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-sync-screen/mb-sync-screen.component.ts
@@ -28,7 +28,7 @@ import { SignInWithGoogleBtnComponent } from 'src/app/shared/components/ui-eleme
   ],
 })
 export class MbSyncScreenComponent {
-  authType: Signal<string> = this.store.selectSignal(UserState.authType);
+  authType: Signal<EUserAuthType | undefined> = this.store.selectSignal(UserState.authType);
 
   syncForm = new UntypedFormGroup({
     password: new UntypedFormControl('', Validators.required),

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-bottom-panel/mb-task-bottom-panel.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-bottom-panel/mb-task-bottom-panel.component.ts
@@ -15,7 +15,7 @@ import {
   imports: [CommonModule],
 })
 export class MbTaskBottomPanelComponent {
-  @Input() enabled: boolean;
+  @Input() enabled!: boolean;
 
   mode: Signal<ETaskViewMode> = this.store.selectSignal(MbTaskScreenState.mode);
 

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-edit/mb-task-edit.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-edit/mb-task-edit.component.ts
@@ -33,11 +33,11 @@ import { VoiceInputTriggerComponent } from 'src/app/shared/features/voice-input/
 })
 export class MbTaskEditComponent {
   formValidStatus = output<boolean>();
-  imageUri$: Observable<string> = inject(Store).select(MbTaskScreenState.imageUri);
+  imageUri$: Observable<string | null> = inject(Store).select(MbTaskScreenState.imageUri);
   voiceToTextConverting$: Observable<boolean> = inject(Store).select(
     VoiceInputState.voiceToTextConverting,
   );
-  form: FormGroup<FormControlsOf<ITaskEditFormData>>;
+  form!: FormGroup<FormControlsOf<ITaskEditFormData>>;
 
   MbTaskScreenState = MbTaskScreenState;
 
@@ -61,7 +61,7 @@ export class MbTaskEditComponent {
   }
 
   onVoiceRecordingStopped(): void {
-    this.form.controls.title.setValue('');
+    this.form.controls.title?.setValue('');
   }
 
   private initSubscriptions(): void {
@@ -95,12 +95,15 @@ export class MbTaskEditComponent {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((payload: { text: string }) => {
-        this.form.controls.title.setValue(payload.text);
+        this.form.controls.title?.setValue(payload.text);
       });
   }
 
   private updateTitleValidation(isRequired: boolean): void {
     const titleControl = this.form.get('title');
+    if (!titleControl) {
+      return;
+    }
 
     isRequired
       ? titleControl.setValidators(this.requiredTitleValidators)

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-screen.actions.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-screen.actions.ts
@@ -8,7 +8,7 @@ export namespace MbTaskScreenAction {
 
     constructor(
       public mode: ETaskViewMode,
-      public taskId: string,
+      public taskId: string | null,
     ) {}
   }
   export class ApplyButtonPressed {

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-screen.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-screen.component.ts
@@ -35,7 +35,7 @@ import { MbTaskBottomPanelComponent } from 'src/app/mobile-app/components/screen
   ],
 })
 export class MbTaskScreenComponent implements OnInit, OnDestroy {
-  @ViewChild('menuDrawer') menuDrawer: MatDrawer;
+  @ViewChild('menuDrawer') menuDrawer!: MatDrawer;
   @ViewChild('titleInput') set titleInput(titleInputElRef: ElementRef) {
     if (titleInputElRef) {
       const titleInput: HTMLInputElement = titleInputElRef.nativeElement;

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-screen.state.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-screen.state.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import type { StateContext } from '@ngxs/store';
 import { State, Action, Selector, Store } from '@ngxs/store';
-import type { Task } from 'src/app/shared/models/task.model';
+import type { DefaultTask, Task } from 'src/app/shared/models/task.model';
 import { ETaskStatus, defaultTask } from 'src/app/shared/models/task.model';
 import { MbTaskScreenAction } from './mb-task-screen.actions';
 import { TasksState } from 'src/app/shared/state/tasks.state';
@@ -21,7 +21,7 @@ export enum ETaskViewMode {
 
 export interface IMbTaskScreenStateModel {
   mode: ETaskViewMode;
-  taskData: Task;
+  taskData: Task | DefaultTask;
   taskViewForm: {
     formData: ITaskEditFormData;
     status: boolean;
@@ -30,7 +30,7 @@ export interface IMbTaskScreenStateModel {
   imageUrl: string | null;
 }
 
-const defaults = {
+const defaults: IMbTaskScreenStateModel = {
   mode: ETaskViewMode.Create,
   taskViewForm: {
     formData: {
@@ -59,7 +59,7 @@ export class MbTaskScreenState {
   }
 
   @Selector()
-  static task(state: IMbTaskScreenStateModel): Task {
+  static task(state: IMbTaskScreenStateModel): Task | DefaultTask {
     return state.taskData;
   }
 
@@ -77,7 +77,7 @@ export class MbTaskScreenState {
   }
 
   @Selector()
-  static imageUri(state: IMbTaskScreenStateModel): string {
+  static imageUri(state: IMbTaskScreenStateModel): string | null {
     return state.imageUrl;
   }
 
@@ -92,7 +92,10 @@ export class MbTaskScreenState {
   }
 
   @Action(MbTaskScreenAction.Opened)
-  opened(ctx: StateContext<IMbTaskScreenStateModel>, { mode, taskId }): void {
+  opened(
+    ctx: StateContext<IMbTaskScreenStateModel>,
+    { mode, taskId }: MbTaskScreenAction.Opened,
+  ): void {
     ctx.dispatch(new VoiceInputAction.Reset());
     ctx.setState({
       ...defaults,
@@ -124,14 +127,16 @@ export class MbTaskScreenState {
 
   private async handleCreateTask(ctx: StateContext<IMbTaskScreenStateModel>): Promise<void> {
     const { taskData, imageUrl } = ctx.getState();
-    const userId: string = this.store.selectSnapshot(UserState.userId);
-
-    let finalTaskData: Task = { ...taskData, imageId: undefined };
-
-    if (imageUrl) {
-      const imageId = await this.imageService.saveImage(imageUrl);
-      finalTaskData = { ...finalTaskData, imageId };
+    const userId = this.store.selectSnapshot(UserState.userId);
+    if (userId == null) {
+      throw new Error('Cannot create a task without a user id');
     }
+
+    let imageId: string | undefined;
+    if (imageUrl) {
+      imageId = await this.imageService.saveImage(imageUrl);
+    }
+    const finalTaskData = { ...taskData, imageId };
 
     ctx.patchState({ taskData: finalTaskData });
     ctx.dispatch(new TasksAction.CreateTask(finalTaskData, userId));
@@ -140,6 +145,9 @@ export class MbTaskScreenState {
 
   private handleUpdateTask(ctx: StateContext<IMbTaskScreenStateModel>): void {
     const taskData = ctx.getState().taskData;
+    if (taskData.id == null) {
+      return;
+    }
 
     ctx.dispatch(
       new TasksAction.UpdateTask({
@@ -178,7 +186,11 @@ export class MbTaskScreenState {
 
   @Action(MbTaskScreenAction.DeleteTaskOptionSelected)
   deleteTask(ctx: StateContext<IMbTaskScreenStateModel>): void {
-    ctx.dispatch(new TasksAction.DeleteTask(ctx.getState().taskData.id));
+    const taskId = ctx.getState().taskData.id;
+    if (taskId == null) {
+      return;
+    }
+    ctx.dispatch(new TasksAction.DeleteTask(taskId));
     ctx.dispatch(AppAction.NavigateToHomeScreen);
   }
 
@@ -232,8 +244,12 @@ export class MbTaskScreenState {
     ctx: StateContext<IMbTaskScreenStateModel>,
     updatedTaskData: Partial<Task>,
   ): void {
+    const taskId = ctx.getState().taskData.id;
+    if (taskId == null) {
+      return;
+    }
     ctx.dispatch([
-      new TasksAction.UpdateTask({ taskId: ctx.getState().taskData.id, changes: updatedTaskData }),
+      new TasksAction.UpdateTask({ taskId, changes: updatedTaskData }),
       MbTaskScreenAction.Close,
     ]);
   }

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.html
@@ -1,20 +1,22 @@
 @let task = task$ | async;
-<div class="title-holder">
-  <span data-test="task-view-title">{{ task.title }}</span>
-</div>
-@if (task?.imageId) {
-  <div class="task-picture-holder">
-    @if (isImageLoading()) {
-      <div class="task-picture-spinner">
-        <ba-spinner></ba-spinner>
-      </div>
-    }
-    <img
-      class="task-picture"
-      [class.is-loading]="isImageLoading()"
-      [src]="task.imageId | imageSrc"
-      (load)="onImageLoaded(task.imageId)"
-      (error)="onImageError(task.imageId)"
-    />
+@if (task) {
+  <div class="title-holder">
+    <span data-test="task-view-title">{{ task.title }}</span>
   </div>
+  @if (task.imageId; as imageId) {
+    <div class="task-picture-holder">
+      @if (isImageLoading()) {
+        <div class="task-picture-spinner">
+          <ba-spinner></ba-spinner>
+        </div>
+      }
+      <img
+        class="task-picture"
+        [class.is-loading]="isImageLoading()"
+        [src]="imageId | imageSrc"
+        (load)="onImageLoaded(imageId)"
+        (error)="onImageError(imageId)"
+      />
+    </div>
+  }
 }

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.ts
@@ -5,7 +5,7 @@ import { Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { distinctUntilChanged, map, tap } from 'rxjs/operators';
 import { MbTaskScreenState } from '../mb-task-screen.state';
-import { Task } from 'src/app/shared/models/task.model';
+import type { DefaultTask, Task } from 'src/app/shared/models/task.model';
 import { ImageSrcPipe } from 'src/app/shared/pipes/image-src.pipe';
 import { SpinnerComponent } from 'src/app/shared/components/ui-elements/spinner/spinner.component';
 
@@ -16,12 +16,15 @@ import { SpinnerComponent } from 'src/app/shared/components/ui-elements/spinner/
   styleUrl: './mb-task-view.component.scss',
 })
 export class MbTaskViewComponent implements OnInit {
-  task$: Observable<Task>;
+  task$: Observable<Task | DefaultTask>;
 
   private currentImageId: string | null = null;
   isImageLoading = signal(true);
 
-  constructor(private store: Store, private destroyRef: DestroyRef) {
+  constructor(
+    private store: Store,
+    private destroyRef: DestroyRef,
+  ) {
     this.task$ = this.store.select(MbTaskScreenState.task);
   }
 

--- a/frontend/src/app/mobile-app/mobile-app.state.ts
+++ b/frontend/src/app/mobile-app/mobile-app.state.ts
@@ -31,7 +31,7 @@ export class MobileAppState {
   }
 
   @Action(MbTaskTileAction.Clicked)
-  openTaskView(ctx: StateContext<MobileAppStateModel>, { taskId }) {
+  openTaskView(ctx: StateContext<MobileAppStateModel>, { taskId }: MbTaskTileAction.Clicked) {
     this.ngZone.run(() => {
       this.router.navigate([`task/${ETaskViewMode.View}/${taskId}`]);
     });

--- a/frontend/src/app/shared/components/redirects/google/google-auth-redirect/google-auth-redirect.component.ts
+++ b/frontend/src/app/shared/components/redirects/google/google-auth-redirect/google-auth-redirect.component.ts
@@ -25,7 +25,7 @@ export class GoogleAuthRedirectScreenComponent {
   ) {}
 
   ngOnInit() {
-    const code: string = this._activatedRoute.snapshot.queryParamMap.get('code');
+    const code = this._activatedRoute.snapshot.queryParamMap.get('code');
     this._store.dispatch(new GoogleAuthRedirectScreenAction.Opened(code));
   }
 

--- a/frontend/src/app/shared/components/redirects/google/google-auth-redirect/google-auth-redirect.state.ts
+++ b/frontend/src/app/shared/components/redirects/google/google-auth-redirect/google-auth-redirect.state.ts
@@ -17,10 +17,14 @@ import { readApiErrorName } from 'src/app/shared/helpers/google-refresh-token-in
 export interface IGoogleAuthRedirectScreenStateModel {
   isLogging: boolean;
   errorOccurred: boolean;
-  errorMessage: string;
+  errorMessage: string | null;
 }
 
-const defaults = { isLogging: true, errorOccurred: false, errorMessage: null };
+const defaults: IGoogleAuthRedirectScreenStateModel = {
+  isLogging: true,
+  errorOccurred: false,
+  errorMessage: null,
+};
 
 @State<IGoogleAuthRedirectScreenStateModel>({
   name: 'googleAuthRedirectScreenState',
@@ -41,7 +45,7 @@ export class GoogleAuthRedirectScreenState {
   }
 
   @Selector()
-  static errorMessage(state: IGoogleAuthRedirectScreenStateModel): string {
+  static errorMessage(state: IGoogleAuthRedirectScreenStateModel): string | null {
     return state.errorMessage;
   }
 

--- a/frontend/src/app/shared/components/redirects/slack/add-to-slack-redirect/add-to-slack-redirect.actions.ts
+++ b/frontend/src/app/shared/components/redirects/slack/add-to-slack-redirect/add-to-slack-redirect.actions.ts
@@ -2,6 +2,6 @@ export namespace AddToSlackRedirectScreenAction {
   export class Opened {
     static readonly type = '[AddToSlackRedirectScreen] Opened';
 
-    constructor(public readonly code: string) {}
+    constructor(public readonly code: string | null) {}
   }
 }

--- a/frontend/src/app/shared/components/redirects/slack/add-to-slack-redirect/add-to-slack-redirect.component.ts
+++ b/frontend/src/app/shared/components/redirects/slack/add-to-slack-redirect/add-to-slack-redirect.component.ts
@@ -26,7 +26,7 @@ export class AddToSlackRedirectComponent {
   ) {}
 
   ngOnInit() {
-    const code: string = this._activatedRoute.snapshot.queryParamMap.get('code');
+    const code = this._activatedRoute.snapshot.queryParamMap.get('code');
     this._store.dispatch(new AddToSlackRedirectScreenAction.Opened(code));
   }
 

--- a/frontend/src/app/shared/components/redirects/slack/add-to-slack-redirect/add-to-slack-redirect.state.ts
+++ b/frontend/src/app/shared/components/redirects/slack/add-to-slack-redirect/add-to-slack-redirect.state.ts
@@ -39,6 +39,14 @@ export class AddToSlackRedirectScreenState {
       errorOccurred: false,
     });
 
+    if (code == null || code === '') {
+      ctx.patchState({
+        isInstalling: false,
+        errorOccurred: true,
+      });
+      return;
+    }
+
     try {
       await this._slackService.addToSlack(code);
 

--- a/frontend/src/app/shared/components/ui-elements/user-avatar/user-avatar.component.ts
+++ b/frontend/src/app/shared/components/ui-elements/user-avatar/user-avatar.component.ts
@@ -7,8 +7,8 @@ import { IUserAvatarInputData } from './user-avatar.interface';
   styleUrls: ['./user-avatar.component.scss'],
 })
 export class UserAvatarComponent {
-  @Input() data: IUserAvatarInputData;
-  @ViewChild('avatarHolder') avatarHolderRef: ElementRef;
+  @Input() data!: IUserAvatarInputData;
+  @ViewChild('avatarHolder') avatarHolderRef!: ElementRef;
 
   constructor(private _el: ElementRef) {}
 
@@ -28,7 +28,7 @@ export class UserAvatarComponent {
     if (this.data.photoUrl) {
       this.avatarHolderRef.nativeElement.style.backgroundImage = `url(${this.data.photoUrl})`;
     } else {
-      this.avatarHolderRef.nativeElement.innerHTML = this.data.firstLetter;
+      this.avatarHolderRef.nativeElement.innerHTML = this.data.firstLetter ?? '';
       if (this.data.color) {
         this.avatarHolderRef.nativeElement.style.background = this.data.color;
       }

--- a/frontend/src/app/shared/components/ui-elements/user-avatar/user-avatar.interface.ts
+++ b/frontend/src/app/shared/components/ui-elements/user-avatar/user-avatar.interface.ts
@@ -1,5 +1,5 @@
 export interface IUserAvatarInputData {
-  firstLetter: string;
+  firstLetter: string | null;
   color?: string;
   photoUrl?: string;
 }

--- a/frontend/src/app/shared/features/voice-input/components/voice-recorder/progress-ring/progress-ring.component.ts
+++ b/frontend/src/app/shared/features/voice-input/components/voice-recorder/progress-ring/progress-ring.component.ts
@@ -144,8 +144,11 @@ export class ProgressRingComponent implements AfterViewInit, OnDestroy {
   // and trigger change detection. If `start()` ran before we had a non-zero radius, `pendingStart`
   // defers the animation until the first valid measurement arrives.
   private setupResizeObserver(): void {
-    this.resizeObserver = new ResizeObserver((entries) => {
+    this.resizeObserver = new ResizeObserver(entries => {
       const entry = entries[0];
+      if (!entry) {
+        return;
+      }
       const rect = entry.contentRect;
       const size = Math.min(rect.width, rect.height);
       const stroke = this.strokeWidth ?? 0;
@@ -164,4 +167,3 @@ export class ProgressRingComponent implements AfterViewInit, OnDestroy {
     this.resizeObserver.observe(this.hostRef.nativeElement);
   }
 }
-

--- a/frontend/src/app/shared/helpers/convert-object-to-url-params.function.ts
+++ b/frontend/src/app/shared/helpers/convert-object-to-url-params.function.ts
@@ -1,7 +1,9 @@
-export function convertObjectToUrlParams(payloadObject): string {
+export function convertObjectToUrlParams(
+  payloadObject: Record<string, string | number | boolean | null | undefined>,
+): string {
   const payload = new URLSearchParams();
   for (const key in payloadObject) {
-    payload.set(key, payloadObject[key]);
+    payload.set(key, String(payloadObject[key]));
   }
 
   return payload.toString();

--- a/frontend/src/app/shared/helpers/google-refresh-token-invalid.function.ts
+++ b/frontend/src/app/shared/helpers/google-refresh-token-invalid.function.ts
@@ -22,5 +22,8 @@ export function isGoogleRefreshTokenInvalidError(error: unknown): boolean {
     return false;
   }
   const name = readApiErrorName(error);
-  return Boolean(name) && GOOGLE_REFRESH_TOKEN_INVALID_NAMES.has(name);
+  if (!name) {
+    return false;
+  }
+  return GOOGLE_REFRESH_TOKEN_INVALID_NAMES.has(name);
 }

--- a/frontend/src/app/shared/mappers/change.mapper.ts
+++ b/frontend/src/app/shared/mappers/change.mapper.ts
@@ -1,4 +1,10 @@
-import { TaskDTO, TagDTO, ChangeDTO, ChangeableObjectDTO, EChangedEntity }  from '@brainassistant/contracts';
+import {
+  TaskDTO,
+  TagDTO,
+  ChangeDTO,
+  ChangeableObjectDTO,
+  EChangedEntity,
+} from '@brainassistant/contracts';
 import { Tag } from '../models';
 import { ChangeableObject, Change } from '../models/change.model';
 import { Task } from '../models/task.model';
@@ -29,7 +35,7 @@ export class ChangeMapper {
     return {
       entity: changeDto.entity as EChangedEntity,
       action: changeDto.action,
-      object: model,
+      object: model ?? undefined,
     };
   }
 

--- a/frontend/src/app/shared/models/index.ts
+++ b/frontend/src/app/shared/models/index.ts
@@ -1,4 +1,6 @@
-export { User } from './user.model';
-export { Task, ETaskStatus, ETaskType, TaskChanges } from './task.model';
-export { Change, ChangeableObject } from './change.model';
-export { Tag, ETagType } from './tag.model';
+export type { User } from './user.model';
+export type { Task, TaskChanges } from './task.model';
+export { ETaskStatus, ETaskType } from './task.model';
+export type { Change, ChangeableObject } from './change.model';
+export type { Tag } from './tag.model';
+export { ETagType } from './tag.model';

--- a/frontend/src/app/shared/models/task.model.ts
+++ b/frontend/src/app/shared/models/task.model.ts
@@ -22,6 +22,8 @@ export const defaultTask = {
   modifiedAt: null,
 };
 
+export type DefaultTask = typeof defaultTask & { imageId?: string };
+
 export type TaskChanges = {
   taskId: string;
   changes: Partial<Task>;

--- a/frontend/src/app/shared/services/api/client-changes.service.ts
+++ b/frontend/src/app/shared/services/api/client-changes.service.ts
@@ -1,7 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Change } from 'src/app/shared/models/change.model';
 import { API_ENDPOINTS } from '../../constants/api-endpoints.const';
-import { ChangeableObjectDTO, ChangeDTO, EChangeAction, EChangedEntity, SendChangeContract } from '@brainassistant/contracts';
+import {
+  ChangeableObjectDTO,
+  ChangeDTO,
+  EChangeAction,
+  EChangedEntity,
+  SendChangeContract,
+} from '@brainassistant/contracts';
 import { ChangeMapper } from '../../mappers/change.mapper';
 import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
@@ -24,7 +30,7 @@ export class ClientChangesService {
   public send(change: Change): Observable<SendChangeContract.Response> {
     try {
       const path = this.getPath(change);
-      
+
       switch (change.action) {
         case EChangeAction.Created:
         case EChangeAction.Updated:
@@ -33,11 +39,11 @@ export class ClientChangesService {
           const request: SendChangeContract.Request = {
             changeableObjectDto: changeDto.object as ChangeableObjectDTO,
           };
-          
+
           return change.action === EChangeAction.Created
             ? this.http.post<SendChangeContract.Response>(path, request)
             : this.http.patch<SendChangeContract.Response>(path, request);
-            
+
         case EChangeAction.Deleted:
           return this.http.delete<SendChangeContract.Response>(path);
       }
@@ -49,6 +55,9 @@ export class ClientChangesService {
 
   private getPath(change: Change): string {
     if (change.action === EChangeAction.Deleted) {
+      if (!change.object) {
+        throw new Error('Cannot build delete path without change.object');
+      }
       return (
         ClientChangesService.SYNC_REQUESTS_MAP[change.entity].endpoint + '/' + change.object.id
       );

--- a/frontend/src/app/shared/services/application/image.service.ts
+++ b/frontend/src/app/shared/services/application/image.service.ts
@@ -25,7 +25,7 @@ export class ImageService {
     return imageId;
   }
 
-  public async getImageRecord(imageId: string): Promise<ImageRecord> {
+  public async getImageRecord(imageId: string): Promise<ImageRecord | undefined> {
     return await this.imageDbService.getImage(imageId);
   }
 
@@ -44,6 +44,9 @@ export class ImageService {
       images.map(async image => {
         try {
           const blob = image.blob;
+          if (!blob) {
+            return;
+          }
           await this.imageUploaderService.uploadImageBlob(image.id, blob);
 
           // set upload to true + url
@@ -57,4 +60,3 @@ export class ImageService {
     );
   }
 }
-

--- a/frontend/src/app/shared/services/integrations/google-api.service.ts
+++ b/frontend/src/app/shared/services/integrations/google-api.service.ts
@@ -18,8 +18,8 @@ export class GoogleAPIService {
     let params = new HttpParams().set('code', code);
     return this.http
       .get<LoginResponseDTO>(GoogleAPIService.AUTH_API_ENDPOINT, {
-        headers: null,
         params: params,
+        responseType: 'json',
       })
       .pipe(
         map(date => {

--- a/frontend/src/app/shared/state/sync.state.ts
+++ b/frontend/src/app/shared/state/sync.state.ts
@@ -13,10 +13,9 @@ import { SyncAction } from './sync.action';
 import { ImageService } from '../services/application/image.service';
 import { UserAction } from './user.actions';
 
-
 export interface SyncStateModel {
-  clientId: string;
-  lastTime: Date;
+  clientId: string | null;
+  lastTime: Date | null;
   changes: Change[];
 }
 
@@ -67,7 +66,7 @@ export class SyncState {
 
   @Action(AppAction.Opened)
   updateSyncTimer(ctx: StateContext<SyncStateModel>): void {
-    clearInterval(this.intervalId);
+    clearInterval(this.intervalId ?? undefined);
     this.intervalId = setInterval(() => {
       ctx.dispatch(new SyncAction.Synchronize());
     }, this.SYNC_PERIOD);
@@ -76,7 +75,7 @@ export class SyncState {
   @Action(UserAction.LoggedOut)
   @Action(AppAction.UserNotAuthenticated)
   clearTimer(): void {
-    clearInterval(this.intervalId);
+    clearInterval(this.intervalId ?? undefined);
   }
 
   @Action(SyncAction.Synchronize)
@@ -88,9 +87,9 @@ export class SyncState {
     try {
       await this.fetchServerChanges(ctx);
       await this.syncPendingChanges(ctx);
-  
+
       ctx.patchState({ lastTime: new Date() });
-      
+
       await this.imageService.uploadImages();
     } catch (err) {
       // TODO: Don't rely only on HTTP status code - check error name from backend response
@@ -104,22 +103,24 @@ export class SyncState {
   }
 
   private async fetchServerChanges(ctx: StateContext<SyncStateModel>): Promise<void> {
-    const changes = await lastValueFrom(
-      this.serverChangesService.fetch(ctx.getState().clientId)
-    );
+    const clientId = ctx.getState().clientId;
+    if (!clientId) {
+      return;
+    }
+    const changes = await lastValueFrom(this.serverChangesService.fetch(clientId));
     await ctx.dispatch(new SyncAction.ServerChangesLoaded(changes));
   }
 
   private async syncPendingChanges(ctx: StateContext<SyncStateModel>): Promise<void> {
     const changes = ctx.getState().changes;
-    
+
     for (const change of changes) {
       try {
         await lastValueFrom(this.clientChangesService.send(change));
         await ctx.dispatch(new SyncAction.LocalChangeWasSynchronized(change));
       } catch (error) {
         console.error('Sync Pending Change Error:', change, error);
-        
+
         // TODO: Don't rely only on HTTP status code - check error name from backend response
         // TICKET: https://brainas.atlassian.net/browse/BA-258
         if (error instanceof HttpErrorResponse && error.status === 404) {
@@ -155,14 +156,20 @@ export class SyncState {
   }
 
   private handleClientIdNotFoundError(ctx: StateContext<SyncStateModel>): void {
-    ctx.patchState({ 
+    ctx.patchState({
       clientId: null,
-      lastTime: null 
+      lastTime: null,
     });
     ctx.dispatch(new SyncAction.Synchronize());
   }
 
-  private async handleEntityNotFoundError(ctx: StateContext<SyncStateModel>, change: Change): Promise<void> {
+  private async handleEntityNotFoundError(
+    ctx: StateContext<SyncStateModel>,
+    change: Change,
+  ): Promise<void> {
+    if (!change.object) {
+      throw new Error('Cannot handle entity-not-found without change.object');
+    }
     // Entity not found on server - create local delete change to sync state with server
     const deleteChange: Change = {
       entity: change.entity,

--- a/frontend/src/app/shared/state/tasks.action.ts
+++ b/frontend/src/app/shared/state/tasks.action.ts
@@ -5,7 +5,7 @@ export namespace TasksAction {
     static readonly type = '[Tasks] Create Task';
 
     constructor(
-      public taskInitData: Task,
+      public taskInitData: Pick<Task, 'title'> & { imageId?: string },
       public userId: string,
     ) {}
   }

--- a/frontend/src/app/shared/state/tasks.state.ts
+++ b/frontend/src/app/shared/state/tasks.state.ts
@@ -3,13 +3,7 @@ import { Injectable } from '@angular/core';
 import { EChangeAction, EChangedEntity } from '@brainassistant/contracts';
 import { patch, append, updateItem, iif, insertItem, removeItem } from '@ngxs/store/operators';
 import { v4 as uuidv4 } from 'uuid';
-import {
-  Task,
-  ETaskStatus,
-  ETaskType,
-  Change,
-  TaskChanges,
-} from 'src/app/shared/models/';
+import { Task, ETaskStatus, ETaskType, Change, TaskChanges } from 'src/app/shared/models/';
 import { UserState } from './user.state';
 import { AppAction } from './app.actions';
 import { SyncAction } from './sync.action';
@@ -30,12 +24,12 @@ export class TasksState {
   static readonly actualStatuses: Array<ETaskStatus> = [ETaskStatus.Todo];
 
   @Selector([TasksState, UserState.userId])
-  static allTasks(state: ITasksStateModel, userId: string): Array<Task> {
+  static allTasks(state: ITasksStateModel, userId: string | null): Array<Task> {
     return this.getSortedUserTasks(state, userId);
   }
 
   @Selector([TasksState, UserState.userId])
-  static actualTasks(state: ITasksStateModel, userId: string): Array<Task> {
+  static actualTasks(state: ITasksStateModel, userId: string | null): Array<Task> {
     return this.getSortedUserTasks(state, userId).filter(t =>
       TasksState.actualStatuses.includes(t.status),
     );
@@ -44,7 +38,10 @@ export class TasksState {
   @Action(TasksAction.CreateTask)
   async createTask(
     ctx: StateContext<ITasksStateModel>,
-    { taskInitData, userId }: { taskInitData: Task; userId: string },
+    {
+      taskInitData,
+      userId,
+    }: { taskInitData: Pick<Task, 'title'> & { imageId?: string }; userId: string },
   ): Promise<void> {
     try {
       const now = this.now();
@@ -87,7 +84,7 @@ export class TasksState {
       }),
     );
 
-    const updatedTask: Task = ctx.getState().entities.find(t => t.id === taskUpdateData.taskId);
+    const updatedTask = ctx.getState().entities.find(t => t.id === taskUpdateData.taskId);
 
     ctx.dispatch(
       new SyncAction.ChangeForSyncOccurred({
@@ -123,14 +120,18 @@ export class TasksState {
   synchronize(ctx: StateContext<ITasksStateModel>, { changes }: { changes: Change[] }): void {
     const taskChanges = changes.filter(c => c.entity === EChangedEntity.Task);
     for (const taskChange of taskChanges) {
+      const changedObject = taskChange.object;
+      if (!changedObject) {
+        continue;
+      }
       if (taskChange.action === EChangeAction.Deleted) {
         ctx.setState(
           patch({
-            entities: removeItem<Task>(task => task.id === taskChange.object.id),
+            entities: removeItem<Task>(task => task.id === changedObject.id),
           }),
         );
       } else {
-        const task = taskChange.object as Task;
+        const task = changedObject as Task;
         ctx.setState(
           patch({
             entities: iif<Array<Task>>(
@@ -144,7 +145,11 @@ export class TasksState {
     }
   }
 
-  private createTaskEntity(taskInitData: Task, userId: string, timestamp: string): Task {
+  private createTaskEntity(
+    taskInitData: Pick<Task, 'title'> & { imageId?: string },
+    userId: string,
+    timestamp: string,
+  ): Task {
     return {
       type: ETaskType.Basic,
       userId,
@@ -157,7 +162,7 @@ export class TasksState {
     };
   }
 
-  private static getSortedUserTasks(state: ITasksStateModel, userId: string): Task[] {
+  private static getSortedUserTasks(state: ITasksStateModel, userId: string | null): Task[] {
     return state.entities
       .filter(e => e.userId === userId)
       .sort((a, b) => {

--- a/frontend/src/app/shared/state/user.state.ts
+++ b/frontend/src/app/shared/state/user.state.ts
@@ -20,8 +20,8 @@ interface IUserIntegrations {
 }
 export interface IUserStateModel {
   userData: User | null;
-  authState: EUserAuthState;
-  authType: EUserAuthType;
+  authState: EUserAuthState | null;
+  authType: EUserAuthType | undefined;
   integrations: IUserIntegrations;
 }
 
@@ -66,7 +66,7 @@ export class UserState {
   }
 
   @Selector()
-  static userNameFirstLetter(state: IUserStateModel): string {
+  static userNameFirstLetter(state: IUserStateModel): string | null {
     if (state.userData) {
       const firstName = state.userData.firstName;
       return firstName ? firstName.charAt(0) : null;
@@ -75,8 +75,8 @@ export class UserState {
   }
 
   @Selector()
-  static userId(state: IUserStateModel): string {
-    return state.userData.userId;
+  static userId(state: IUserStateModel): string | null {
+    return state.userData?.userId ?? null;
   }
 
   @Selector()
@@ -86,16 +86,16 @@ export class UserState {
 
   @Selector()
   static userEmail(state: IUserStateModel): string | null {
-    return state.userData?.email;
+    return state.userData?.email ?? null;
   }
 
   @Selector()
-  static isAddedToSlack(state: IUserStateModel): boolean {
+  static isAddedToSlack(state: IUserStateModel): boolean | undefined {
     return state.integrations.isAddedToSlack;
   }
 
   @Selector()
-  static authType(state: IUserStateModel): EUserAuthType {
+  static authType(state: IUserStateModel): EUserAuthType | undefined {
     return state.authType;
   }
 
@@ -186,8 +186,11 @@ export class UserState {
     ctx: StateContext<IUserStateModel>,
     { password }: { password: string },
   ): Promise<void> {
-    const email = ctx.getState().userData.email;
-    this.loginUser(ctx, email, password);
+    const userData = ctx.getState().userData;
+    if (!userData) {
+      return;
+    }
+    this.loginUser(ctx, userData.email, password);
   }
 
   @Action(SlackAPIAction.AddedToSlack)

--- a/frontend/tests/unit/state/mb-task-screen.state.spec.ts
+++ b/frontend/tests/unit/state/mb-task-screen.state.spec.ts
@@ -83,8 +83,9 @@ describe('MbTaskScreenState', () => {
       .find(t => t.id !== existingWithPhoto.id);
 
     expect(imageService.saveImage).not.toHaveBeenCalled();
+    expect(created).toBeDefined();
     expect(created).toMatchObject({ title: 'Fresh task title', userId });
-    expect(created.imageId).toBeUndefined();
+    expect(created?.imageId).toBeUndefined();
   });
 
   it('still saves a photo taken during the current create session', async () => {
@@ -104,7 +105,7 @@ describe('MbTaskScreenState', () => {
       .find(t => t.id !== existingWithPhoto.id);
 
     expect(imageService.saveImage).toHaveBeenCalledWith('blob:current-session-photo');
-    expect(created.imageId).toBe('new-image-id');
+    expect(created?.imageId).toBe('new-image-id');
   });
 
   it('loads the selected task when opening view mode', async () => {

--- a/frontend/tests/unit/state/tasks.state.spec.ts
+++ b/frontend/tests/unit/state/tasks.state.spec.ts
@@ -53,9 +53,7 @@ describe('TasksState', () => {
 
   it('creates a task optimistically and filters allTasks by userId', async () => {
     await firstValueFrom(
-      store.dispatch(
-        new TasksAction.CreateTask({ title: 'Fresh task title' } as Task, userId),
-      ),
+      store.dispatch(new TasksAction.CreateTask({ title: 'Fresh task title' } as Task, userId)),
     );
 
     const all = store.selectSnapshot(TasksState.allTasks);
@@ -65,7 +63,7 @@ describe('TasksState', () => {
       userId,
       status: ETaskStatus.Todo,
     });
-    expect(all[0].id).toBeTruthy();
+    expect(all[0]?.id).toBeTruthy();
   });
 
   it('updates a task title in place', async () => {
@@ -78,7 +76,7 @@ describe('TasksState', () => {
       ),
     );
 
-    expect(store.selectSnapshot(TasksState.allTasks)[0].title).toBe('Renamed task title');
+    expect(store.selectSnapshot(TasksState.allTasks)[0]?.title).toBe('Renamed task title');
   });
 
   it('removes a task on local delete', async () => {
@@ -116,9 +114,9 @@ describe('TasksState', () => {
       inserted.id,
       existing.id,
     ]);
-    expect(store.selectSnapshot(s => s.tasks.entities.find(t => t.id === existing.id)?.title)).toBe(
-      'Title from server',
-    );
+    expect(
+      store.selectSnapshot(s => s.tasks.entities.find((t: Task) => t.id === existing.id)?.title),
+    ).toBe('Title from server');
 
     await firstValueFrom(
       store.dispatch(

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,7 +12,10 @@
     "importHelpers": true,
     "target": "ES2022",
     "lib": ["ES2022", "dom"],
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
## Summary
- Turn on `strict` and `noUncheckedIndexedAccess` for backend and frontend `tsc`, so nullability and implicit `any` fail at compile time instead of by convention.
- Narrow real holes the compiler found (nullable `findOne` results, optional env/params, create-task `userId` taken from the authenticated session rather than the DTO).
- Add frontend `npm run typecheck` and run it in CI. `exactOptionalPropertyTypes` and Angular `strictTemplates` are left for a follow-up.

## Test plan
- [ ] `cd backend; npm run typecheck`
- [ ] `cd backend; npm test`
- [ ] `cd frontend; npm run typecheck`
- [ ] `cd frontend; npm test`
- [ ] Confirm frontend CI Typecheck step is green