### PR TITLE
fix(frontend): reconnect Google when the Drive refresh token is invalid

### DIFF
--- a/frontend/e2e/google-refresh-token.spec.ts
+++ b/frontend/e2e/google-refresh-token.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { setupApiMocks } from './utils/api-mocks.util';
+import { signIn } from './utils/task-flow.util';
+
+test('invalid Google refresh token on image upload opens consent', async ({ page }) => {
+  await setupApiMocks(page, { failGoogleRefreshToken: true });
+  await signIn(page);
+
+  await page.click('[data-test="new-task-btn"]');
+  await page.waitForURL('/task/TASK_VIEW_MODE_CREATE');
+  await page.fill('[data-test="task-title-input"]', 'Task needing Google reconnect');
+  await page.click('[data-test="add-image-btn"]');
+  await expect(page.locator('[data-test="task-picture"]')).toBeVisible();
+
+  const uploadPromise = page.waitForResponse(
+    response =>
+      response.url().includes('/api/files/image') && response.request().method() === 'POST',
+    { timeout: 30000 },
+  );
+
+  await page.locator('[data-test="apply-changes-btn"]').click();
+  const uploadResponse = await uploadPromise;
+  expect(uploadResponse.status()).toBe(403);
+
+  await page.waitForURL(/oauth-consent-screen/);
+});

--- a/frontend/e2e/utils/api-mocks.util.ts
+++ b/frontend/e2e/utils/api-mocks.util.ts
@@ -1,6 +1,7 @@
 import { Page } from '@playwright/test';
 import {
   EApiError,
+  EUploadImageUseCaseError,
   type ApiErrorDto,
   type GetChangesContract,
   type SendChangeContract,
@@ -11,6 +12,8 @@ import {
 export type SetupApiMocksOptions = {
   /** POST /api/sync/task returns 500; the task stays in the client sync queue. */
   failTaskSync?: boolean;
+  /** POST /api/files/image returns 403 Google refresh token invalid. */
+  failGoogleRefreshToken?: boolean;
 };
 
 type ReleaseClientIdResponse = { clientId: string };
@@ -85,8 +88,34 @@ export async function setupApiMocks(page: Page, options: SetupApiMocksOptions = 
     }
 
     if (url.includes('/api/files/image') && method === 'POST') {
+      if (options.failGoogleRefreshToken) {
+        const body: ApiErrorDto = {
+          name: EUploadImageUseCaseError.GoogleRefreshTokenInvalid,
+          message: 'Google refresh token is invalid or revoked',
+        };
+        await route.fulfill(json(403, body));
+        return;
+      }
       const body: UploadImageContract.Response = { imageId: 'mock-uploaded-image-id' };
       await route.fulfill(json(200, body));
+      return;
+    }
+
+    if (url.includes('/api/files/image') && method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/jpeg',
+        body: Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
+      });
+      return;
+    }
+
+    if (url.includes('/api/integrations/google/oauth-consent-screen')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: 'google-oauth-consent',
+      });
       return;
     }
 

--- a/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tile/task-tile.component.html
+++ b/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tile/task-tile.component.html
@@ -9,7 +9,7 @@
         <img
           [src]="task.imageId | imageSrc: calculatedImageWidth()"
           (load)="isLoading.set(false)"
-          (error)="isLoading.set(false)"
+          (error)="onImageError($event)"
         />
       }
     </div>

--- a/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tile/task-tile.component.ts
+++ b/frontend/src/app/mobile-app/components/common/task-tiles-panel/task-tile/task-tile.component.ts
@@ -40,6 +40,19 @@ export class TaskTileComponent {
     this.calculateImageWidth();
   }
 
+  onImageError(event: Event): void {
+    this.isLoading.set(false);
+    if (!this.isRemoteImageEvent(event) || !this.task.imageId) {
+      return;
+    }
+    this.imageService.probeRemoteImage(this.task.imageId);
+  }
+
+  private isRemoteImageEvent(event: Event): boolean {
+    const image = event.target;
+    return image instanceof HTMLImageElement && !image.src.startsWith('blob:');
+  }
+
   private calculateImageWidth(): void {
     const width =
       this.spinnerComponent?.getNativeElement()?.offsetWidth || this.DEFAULT_IMAGE_WIDTH;

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.html
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.html
@@ -15,7 +15,7 @@
         [class.is-loading]="isImageLoading()"
         [src]="imageId | imageSrc"
         (load)="onImageLoaded(imageId)"
-        (error)="onImageError(imageId)"
+        (error)="onImageError($event, imageId)"
       />
     </div>
   }

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-view/mb-task-view.component.ts
@@ -8,6 +8,7 @@ import { MbTaskScreenState } from '../mb-task-screen.state';
 import type { DefaultTask, Task } from 'src/app/shared/models/task.model';
 import { ImageSrcPipe } from 'src/app/shared/pipes/image-src.pipe';
 import { SpinnerComponent } from 'src/app/shared/components/ui-elements/spinner/spinner.component';
+import { ImageService } from 'src/app/shared/services/application/image.service';
 
 @Component({
   selector: 'ba-mb-task-view',
@@ -24,6 +25,7 @@ export class MbTaskViewComponent implements OnInit {
   constructor(
     private store: Store,
     private destroyRef: DestroyRef,
+    private imageService: ImageService,
   ) {
     this.task$ = this.store.select(MbTaskScreenState.task);
   }
@@ -48,9 +50,13 @@ export class MbTaskViewComponent implements OnInit {
     }
   }
 
-  onImageError(imageId: string): void {
+  onImageError(event: Event, imageId: string): void {
     if (this.currentImageId === imageId) {
       this.isImageLoading.set(false);
+    }
+    const image = event.target;
+    if (image instanceof HTMLImageElement && !image.src.startsWith('blob:')) {
+      this.imageService.probeRemoteImage(imageId);
     }
   }
 }

--- a/frontend/src/app/shared/components/redirects/google/google-auth-redirect/google-auth-redirect.state.ts
+++ b/frontend/src/app/shared/components/redirects/google/google-auth-redirect/google-auth-redirect.state.ts
@@ -8,11 +8,8 @@ import { User } from 'src/app/shared/models';
 import { EMPTY, catchError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { EGoogleAuthUseCaseError } from '@brainassistant/contracts';
-import {
-  GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY,
-  GOOGLE_OAUTH_FORCE_CONSENT_URL,
-} from 'src/app/shared/constants/google-oauth.const';
-import { readApiErrorName } from 'src/app/shared/helpers/google-refresh-token-invalid.function';
+import { GoogleOAuthConsentService } from 'src/app/shared/services/integrations/google-oauth-consent.service';
+import { readApiErrorName } from 'src/app/shared/helpers/http-error-body.function';
 
 export interface IGoogleAuthRedirectScreenStateModel {
   isLogging: boolean;
@@ -32,7 +29,10 @@ const defaults: IGoogleAuthRedirectScreenStateModel = {
 })
 @Injectable()
 export class GoogleAuthRedirectScreenState {
-  constructor(private googleAPIService: GoogleAPIService) {}
+  constructor(
+    private googleAPIService: GoogleAPIService,
+    private readonly googleOAuthConsentService: GoogleOAuthConsentService,
+  ) {}
 
   @Selector()
   static isLogging(state: IGoogleAuthRedirectScreenStateModel): boolean {
@@ -56,7 +56,7 @@ export class GoogleAuthRedirectScreenState {
   ): Promise<void> {
     ctx.patchState({ ...defaults });
 
-    if (payload.code == null || payload.code === '') {
+    if (payload.code === undefined || payload.code === null || payload.code === '') {
       ctx.patchState({
         isLogging: false,
         errorOccurred: true,
@@ -80,7 +80,7 @@ export class GoogleAuthRedirectScreenState {
     ctx: StateContext<IGoogleAuthRedirectScreenStateModel>,
     user: User,
   ): void {
-    sessionStorage.removeItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY);
+    this.googleOAuthConsentService.clearForceConsentAttempt();
     ctx.patchState({ isLogging: false });
     ctx.dispatch(new UserAction.UserAuthenticatedWithGoogle(user));
     ctx.dispatch(AppAction.NavigateToProfileScreen);
@@ -104,7 +104,7 @@ export class GoogleAuthRedirectScreenState {
     }
 
     if (errorCode === EGoogleAuthUseCaseError.AuthorizationFailed) {
-      sessionStorage.removeItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY);
+      this.googleOAuthConsentService.clearForceConsentAttempt();
       ctx.patchState({
         errorMessage: 'Google code expired. Please try signing in again.',
       });
@@ -121,14 +121,10 @@ export class GoogleAuthRedirectScreenState {
    * We redirect once; flag avoids an endless loop if consent still yields no token.
    */
   private retryOnceWithForcedGoogleConsent(): void {
-    const alreadyRetried = sessionStorage.getItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY) === '1';
-
-    if (!alreadyRetried) {
-      sessionStorage.setItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY, '1');
-      window.location.href = GOOGLE_OAUTH_FORCE_CONSENT_URL;
+    if (this.googleOAuthConsentService.hasRecentForceConsentAttempt()) {
+      this.googleOAuthConsentService.clearForceConsentAttempt();
       return;
     }
-
-    sessionStorage.removeItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY);
+    this.googleOAuthConsentService.openForceConsentScreen();
   }
 }

--- a/frontend/src/app/shared/constants/google-oauth.const.ts
+++ b/frontend/src/app/shared/constants/google-oauth.const.ts
@@ -8,5 +8,8 @@ export const GOOGLE_OAUTH_CONSENT_URL = `${environment.baseUrl}${CONSENT_SCREEN_
 /** Re-consent so Google issues a new refresh token. */
 export const GOOGLE_OAUTH_FORCE_CONSENT_URL = `${environment.baseUrl}${CONSENT_SCREEN_PATH}?forceConsent=1&ngsw-bypass=1`;
 
-/** Session flag that stops an automatic consent-retry loop. */
+/** Session key for the last force-consent attempt. Older builds stored `'1'`. */
 export const GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY = 'google_force_consent_attempted';
+
+/** Ignore a second auto-redirect within this window so sync retries cannot loop. */
+export const GOOGLE_FORCE_CONSENT_COOLDOWN_MS = 60_000;

--- a/frontend/src/app/shared/helpers/google-refresh-token-invalid.function.ts
+++ b/frontend/src/app/shared/helpers/google-refresh-token-invalid.function.ts
@@ -1,21 +1,11 @@
 import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { EGetImageUseCaseError, EUploadImageUseCaseError } from '@brainassistant/contracts';
+import { readApiErrorName } from './http-error-body.function';
 
 const GOOGLE_REFRESH_TOKEN_INVALID_NAMES = new Set<string>([
   EGetImageUseCaseError.GoogleRefreshTokenInvalid,
   EUploadImageUseCaseError.GoogleRefreshTokenInvalid,
 ]);
-
-export function readApiErrorName(error: HttpErrorResponse): string | undefined {
-  const payload = error.error as { name?: unknown; code?: unknown } | undefined;
-  if (typeof payload?.name === 'string') {
-    return payload.name;
-  }
-  if (typeof payload?.code === 'string') {
-    return payload.code;
-  }
-  return undefined;
-}
 
 export function isGoogleRefreshTokenInvalidError(error: unknown): boolean {
   if (!(error instanceof HttpErrorResponse) || error.status !== HttpStatusCode.Forbidden) {

--- a/frontend/src/app/shared/helpers/http-error-body.function.ts
+++ b/frontend/src/app/shared/helpers/http-error-body.function.ts
@@ -1,0 +1,98 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
+export function readApiErrorName(error: HttpErrorResponse): string | undefined {
+  return readApiErrorNameFromBody(error.error);
+}
+
+function readApiErrorNameFromBody(body: unknown): string | undefined {
+  if (typeof body === 'string') {
+    return readApiErrorNameFromBody(parseJsonObject(body));
+  }
+  if (body === null || body === undefined || typeof body !== 'object' || Array.isArray(body)) {
+    return undefined;
+  }
+  if (isBlobLike(body) || body instanceof ArrayBuffer) {
+    return undefined;
+  }
+  const payload = body as { name?: unknown; code?: unknown };
+  if (typeof payload.name === 'string') {
+    return payload.name;
+  }
+  if (typeof payload.code === 'string') {
+    return payload.code;
+  }
+  return undefined;
+}
+
+/**
+ * HttpClient leaves JSON error bodies as a Blob when the request used
+ * `responseType: 'blob'` (image GET). Parse those back to an object so
+ * callers can read `name` / `code`.
+ */
+export async function normalizeHttpErrorResponse(
+  error: HttpErrorResponse,
+): Promise<HttpErrorResponse> {
+  const body = error.error;
+  if (typeof body === 'string') {
+    const parsed = parseJsonObject(body);
+    return parsed === undefined ? error : cloneHttpError(error, parsed);
+  }
+  if (isBlobLike(body)) {
+    try {
+      const parsed = parseJsonObject(await blobToText(body));
+      return parsed === undefined ? error : cloneHttpError(error, parsed);
+    } catch {
+      return error;
+    }
+  }
+  return error;
+}
+
+function isBlobLike(body: unknown): body is Blob {
+  if (typeof Blob !== 'undefined' && body instanceof Blob) {
+    return true;
+  }
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    typeof (body as { size?: unknown }).size === 'number' &&
+    typeof (body as { arrayBuffer?: unknown }).arrayBuffer === 'function'
+  );
+}
+
+async function blobToText(body: Blob): Promise<string> {
+  if (typeof body.text === 'function') {
+    return body.text();
+  }
+  if (typeof Response !== 'undefined') {
+    return await new Response(body).text();
+  }
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read blob'));
+    reader.readAsText(body);
+  });
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function cloneHttpError(error: HttpErrorResponse, body: unknown): HttpErrorResponse {
+  return new HttpErrorResponse({
+    error: body,
+    headers: error.headers,
+    status: error.status,
+    statusText: error.statusText,
+    url: error.url ?? undefined,
+  });
+}

--- a/frontend/src/app/shared/pipes/image-src.pipe.ts
+++ b/frontend/src/app/shared/pipes/image-src.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
-import { ImageDbService } from '../services/infrastructure/image-db.service';
 import { API_ENDPOINTS } from '../constants/api-endpoints.const';
+import { ImageService } from '../services/application/image.service';
 
 @Pipe({
   name: 'imageSrc',
@@ -13,7 +13,7 @@ export class ImageSrcPipe implements PipeTransform, OnDestroy {
   private latestValue: SafeUrl | string | null = null;
 
   constructor(
-    private imageDb: ImageDbService,
+    private imageService: ImageService,
     private sanitizer: DomSanitizer,
     private cd: ChangeDetectorRef,
   ) {}
@@ -21,44 +21,60 @@ export class ImageSrcPipe implements PipeTransform, OnDestroy {
   transform(id: string | null | undefined, width?: number): SafeUrl | string | null {
     if (!id) {
       this.revokeUrl();
+      this.latestId = undefined;
       this.latestValue = null;
       return this.latestValue;
     }
 
     if (id !== this.latestId) {
       this.latestId = id;
-      this.imageDb
-        .getImage(id)
-        .then(record => {
-          this.revokeUrl();
-
-          if (record?.blob) {
-            this.currentUrl = URL.createObjectURL(record.blob);
-            this.latestValue = this.sanitizer.bypassSecurityTrustUrl(this.currentUrl); // NOSONAR blob: createObjectURL from in-app Blob, img src only
-          } else {
-            const baseUrl = `${API_ENDPOINTS.FILES.IMAGE}/${id}`;
-            this.latestValue = width ? `${baseUrl}?width=${width}` : baseUrl;
-          }
-
-          this.cd.markForCheck();
-        })
-        .catch(() => {
-          this.latestValue = null;
-          this.cd.markForCheck();
-        });
+      void this.load(id, width);
     }
 
     return this.latestValue;
   }
 
-  private revokeUrl() {
+  ngOnDestroy(): void {
+    this.revokeUrl();
+  }
+
+  private async load(id: string, width?: number): Promise<void> {
+    try {
+      const record = await this.imageService.getImageRecord(id);
+      if (this.latestId !== id) {
+        return;
+      }
+
+      this.revokeUrl();
+
+      if (record?.blob) {
+        this.setObjectUrl(record.blob);
+        return;
+      }
+
+      const baseUrl = `${API_ENDPOINTS.FILES.IMAGE}/${id}`;
+      this.latestValue = width !== undefined ? `${baseUrl}?width=${width}` : baseUrl;
+      this.cd.markForCheck();
+    } catch {
+      if (this.latestId !== id) {
+        return;
+      }
+      this.revokeUrl();
+      this.latestValue = null;
+      this.cd.markForCheck();
+    }
+  }
+
+  private setObjectUrl(blob: Blob): void {
+    this.currentUrl = URL.createObjectURL(blob);
+    this.latestValue = this.sanitizer.bypassSecurityTrustUrl(this.currentUrl); // NOSONAR blob: createObjectURL from in-app Blob, img src only
+    this.cd.markForCheck();
+  }
+
+  private revokeUrl(): void {
     if (this.currentUrl) {
       URL.revokeObjectURL(this.currentUrl);
       this.currentUrl = undefined;
     }
-  }
-
-  ngOnDestroy() {
-    this.revokeUrl();
   }
 }

--- a/frontend/src/app/shared/services/api/image-uploader.service.ts
+++ b/frontend/src/app/shared/services/api/image-uploader.service.ts
@@ -16,15 +16,18 @@ export class ImageUploaderService {
     try {
       const extension = mime.getExtension(blob.type) || 'jpg';
       const filename = `${uuidv4()}.${extension}`;
-      
+
       // Build request according to UploadImageContract.Request
       const request: UploadImageContract.Request = {
         imageId,
         file: blob,
       };
-      
+
       return await firstValueFrom(
-        this.http.post<UploadImageContract.Response>(API_ENDPOINTS.FILES.IMAGE, this.mapRequestToFormData(request, filename)),
+        this.http.post<UploadImageContract.Response>(
+          API_ENDPOINTS.FILES.IMAGE,
+          this.mapRequestToFormData(request, filename),
+        ),
       );
     } catch (error) {
       console.error('Error uploading image:', error);

--- a/frontend/src/app/shared/services/application/image.service.ts
+++ b/frontend/src/app/shared/services/application/image.service.ts
@@ -1,18 +1,28 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Store } from '@ngxs/store';
+import { firstValueFrom } from 'rxjs';
 import { ImageDbService, ImageRecord } from '../infrastructure/image-db.service';
 import { ImageOptimizerService } from '../utility/image-optimizer.service';
 import { ImageUploaderService } from '../api/image-uploader.service';
 import { FetchService } from '../infrastructure/fetch.service';
 import { UuidGeneratorService } from '../adapters/uuid-generator.service';
+import { isGoogleRefreshTokenInvalidError } from '../../helpers/google-refresh-token-invalid.function';
+import { AppAction } from '../../state/app.actions';
+import { API_ENDPOINTS } from '../../constants/api-endpoints.const';
 
 @Injectable({ providedIn: 'root' })
 export class ImageService {
+  private hasProbedRemoteImage = false;
+
   constructor(
     private readonly imageDbService: ImageDbService,
     private readonly imageOptimizerService: ImageOptimizerService,
     private readonly imageUploaderService: ImageUploaderService,
     private readonly fetchService: FetchService,
     private readonly uuidGeneratorService: UuidGeneratorService,
+    private readonly injector: Injector,
+    private readonly http: HttpClient,
   ) {}
 
   public async saveImage(imageUri: string): Promise<string> {
@@ -27,6 +37,21 @@ export class ImageService {
 
   public async getImageRecord(imageId: string): Promise<ImageRecord | undefined> {
     return await this.imageDbService.getImage(imageId);
+  }
+
+  /**
+   * `<img src>` does not go through HttpClient. At most one GET per app session
+   * so a Drive 403 still reaches the interceptor; a list of broken thumbnails
+   * must not each fire their own request.
+   */
+  public probeRemoteImage(imageId: string): void {
+    if (this.hasProbedRemoteImage) {
+      return;
+    }
+    this.hasProbedRemoteImage = true;
+    void firstValueFrom(
+      this.http.get(`${API_ENDPOINTS.FILES.IMAGE}/${imageId}`, { responseType: 'blob' }),
+    ).catch(() => undefined);
   }
 
   public async convertBlobUriToBlob(imageUri: string, quality: number = 0.6): Promise<Blob> {
@@ -55,6 +80,9 @@ export class ImageService {
           });
         } catch (error) {
           console.error(`Failed to upload image ${image.id}:`, error);
+          if (isGoogleRefreshTokenInvalidError(error)) {
+            this.injector.get(Store).dispatch(new AppAction.GoogleRefreshTokenInvalid());
+          }
         }
       }),
     );

--- a/frontend/src/app/shared/services/infrastructure/http-interceptor.service.ts
+++ b/frontend/src/app/shared/services/infrastructure/http-interceptor.service.ts
@@ -5,13 +5,15 @@ import {
   HttpHandler,
   HttpInterceptor,
   HttpRequest,
+  HttpStatusCode,
 } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { from, Observable, throwError } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { AppAction } from '../../state/app.actions';
 import { isGoogleRefreshTokenInvalidError } from '../../helpers/google-refresh-token-invalid.function';
+import { normalizeHttpErrorResponse } from '../../helpers/http-error-body.function';
 
 @Injectable()
 export class HttpInterceptorService implements HttpInterceptor {
@@ -23,20 +25,32 @@ export class HttpInterceptorService implements HttpInterceptor {
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(req).pipe(
       catchError((error: unknown) => {
-        if (error instanceof HttpErrorResponse && error.status === 401) {
-          this._store.dispatch(AppAction.UserNotAuthenticated);
-        }
-        if (isGoogleRefreshTokenInvalidError(error)) {
-          this._store.dispatch(new AppAction.GoogleRefreshTokenInvalid());
-        }
-        if (error instanceof HttpErrorResponse && error.status === 500) {
-          // TICKET: https://brainas.atlassian.net/browse/BA-135
-          // TODO: Log Unexpected Error On Client and notify user
-          console.log('Unexpected Error');
-          console.log(error);
-        }
-        return throwError(() => error);
+        return from(this.onHttpError(error)).pipe(switchMap(() => throwError(() => error)));
       }),
     );
+  }
+
+  private async onHttpError(error: unknown): Promise<void> {
+    const httpError =
+      error instanceof HttpErrorResponse ? await normalizeHttpErrorResponse(error) : error;
+
+    if (
+      httpError instanceof HttpErrorResponse &&
+      httpError.status === HttpStatusCode.Unauthorized
+    ) {
+      this._store.dispatch(AppAction.UserNotAuthenticated);
+    }
+    if (isGoogleRefreshTokenInvalidError(httpError)) {
+      this._store.dispatch(new AppAction.GoogleRefreshTokenInvalid());
+    }
+    if (
+      httpError instanceof HttpErrorResponse &&
+      httpError.status === HttpStatusCode.InternalServerError
+    ) {
+      // TICKET: https://brainas.atlassian.net/browse/BA-135
+      // TODO: Log Unexpected Error On Client and notify user
+      console.log('Unexpected Error');
+      console.log(httpError);
+    }
   }
 }

--- a/frontend/src/app/shared/services/integrations/google-oauth-consent.service.ts
+++ b/frontend/src/app/shared/services/integrations/google-oauth-consent.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import {
   GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY,
+  GOOGLE_FORCE_CONSENT_COOLDOWN_MS,
   GOOGLE_OAUTH_FORCE_CONSENT_URL,
 } from '../../constants/google-oauth.const';
 
@@ -10,11 +11,28 @@ import {
 export class GoogleOAuthConsentService {
   /** Opens Google consent with prompt=consent so a new refresh token can be issued. */
   openForceConsentScreen(): void {
-    if (sessionStorage.getItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY) === '1') {
+    if (this.hasRecentForceConsentAttempt()) {
       return;
     }
-    sessionStorage.setItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY, '1');
+    this.markForceConsentAttempt();
     window.location.assign(GOOGLE_OAUTH_FORCE_CONSENT_URL);
+  }
+
+  hasRecentForceConsentAttempt(): boolean {
+    const storedTimestamp = sessionStorage.getItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY);
+    // Missing, or the old boolean `'1'` from an earlier build — allow a new attempt.
+    if (!storedTimestamp || storedTimestamp === '1') {
+      return false;
+    }
+    const lastAttemptMs = Number(storedTimestamp);
+    if (!Number.isFinite(lastAttemptMs)) {
+      return false;
+    }
+    return Date.now() - lastAttemptMs < GOOGLE_FORCE_CONSENT_COOLDOWN_MS;
+  }
+
+  markForceConsentAttempt(): void {
+    sessionStorage.setItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY, String(Date.now()));
   }
 
   /** After a new grant is stored, allow a later invalid-token redirect in this tab. */

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -29,7 +29,6 @@ bootstrapApplication(AppComponent, {
       }),
     ),
     provideStates([AppState, UserState, SyncState, TasksState]),
-    provideHttpClient(),
     provideNoopAnimations(),
     provideRouter(mobileRoutes),
     importProvidersFrom(

--- a/frontend/tests/unit/helpers/google-refresh-token-invalid.spec.ts
+++ b/frontend/tests/unit/helpers/google-refresh-token-invalid.spec.ts
@@ -1,9 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { EGetImageUseCaseError, EUploadImageUseCaseError } from '@brainassistant/contracts';
-import {
-  isGoogleRefreshTokenInvalidError,
-  readApiErrorName,
-} from 'src/app/shared/helpers/google-refresh-token-invalid.function';
+import { isGoogleRefreshTokenInvalidError } from 'src/app/shared/helpers/google-refresh-token-invalid.function';
 
 function httpError(status: number, body: unknown): HttpErrorResponse {
   return new HttpErrorResponse({ status, error: body });
@@ -31,6 +28,17 @@ describe('isGoogleRefreshTokenInvalidError', () => {
     ).toBe(true);
   });
 
+  it('reads a JSON string body', () => {
+    expect(
+      isGoogleRefreshTokenInvalidError(
+        httpError(
+          403,
+          JSON.stringify({ name: EUploadImageUseCaseError.GoogleRefreshTokenInvalid }),
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it('ignores other 403s and non-HTTP errors', () => {
     expect(
       isGoogleRefreshTokenInvalidError(
@@ -41,9 +49,5 @@ describe('isGoogleRefreshTokenInvalidError', () => {
       false,
     );
     expect(isGoogleRefreshTokenInvalidError(new Error('invalid_grant'))).toBe(false);
-  });
-
-  it('readApiErrorName prefers name over code', () => {
-    expect(readApiErrorName(httpError(403, { name: 'A', code: 'B' }))).toBe('A');
   });
 });

--- a/frontend/tests/unit/helpers/http-error-body.spec.ts
+++ b/frontend/tests/unit/helpers/http-error-body.spec.ts
@@ -1,0 +1,26 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { EGetImageUseCaseError } from '@brainassistant/contracts';
+import { isGoogleRefreshTokenInvalidError } from 'src/app/shared/helpers/google-refresh-token-invalid.function';
+import {
+  normalizeHttpErrorResponse,
+  readApiErrorName,
+} from 'src/app/shared/helpers/http-error-body.function';
+
+function httpError(status: number, body: unknown): HttpErrorResponse {
+  return new HttpErrorResponse({ status, error: body });
+}
+
+describe('http error body', () => {
+  it('readApiErrorName prefers name over code', () => {
+    expect(readApiErrorName(httpError(403, { name: 'A', code: 'B' }))).toBe('A');
+  });
+
+  it('parses a JSON blob from a responseType: blob request', async () => {
+    const blob = new Blob(
+      [JSON.stringify({ name: EGetImageUseCaseError.GoogleRefreshTokenInvalid })],
+      { type: 'application/json' },
+    );
+    const normalized = await normalizeHttpErrorResponse(httpError(403, blob));
+    expect(isGoogleRefreshTokenInvalidError(normalized)).toBe(true);
+  });
+});

--- a/frontend/tests/unit/pipes/image-src.pipe.spec.ts
+++ b/frontend/tests/unit/pipes/image-src.pipe.spec.ts
@@ -1,0 +1,128 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
+import { ImageService } from 'src/app/shared/services/application/image.service';
+import { ImageSrcPipe } from 'src/app/shared/pipes/image-src.pipe';
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('ImageSrcPipe', () => {
+  let pipe: ImageSrcPipe;
+  let imageService: { getImageRecord: jest.Mock };
+  let createObjectURL: jest.Mock;
+  let revokeObjectURL: jest.Mock;
+  const localBlob = new Blob(['local']);
+  const otherBlob = new Blob(['other']);
+
+  beforeEach(() => {
+    imageService = { getImageRecord: jest.fn() };
+    createObjectURL = jest.fn((blob: Blob) => `blob:${blob === localBlob ? 'local' : 'other'}`);
+    revokeObjectURL = jest.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: revokeObjectURL,
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        ImageSrcPipe,
+        { provide: ImageService, useValue: imageService },
+        { provide: ChangeDetectorRef, useValue: { markForCheck: jest.fn() } },
+        { provide: DomSanitizer, useValue: { bypassSecurityTrustUrl: (url: string) => url } },
+      ],
+    });
+    pipe = TestBed.inject(ImageSrcPipe);
+  });
+
+  it('returns null when there is no image id', () => {
+    expect(pipe.transform(null)).toBeNull();
+    expect(pipe.transform(undefined)).toBeNull();
+    expect(pipe.transform('')).toBeNull();
+    expect(imageService.getImageRecord).not.toHaveBeenCalled();
+  });
+
+  it('uses the IndexedDB blob and skips HTTP when the image is on the device', async () => {
+    imageService.getImageRecord.mockResolvedValue({ id: 'img-1', blob: localBlob, uploaded: true });
+
+    expect(pipe.transform('img-1')).toBeNull();
+    await flushMicrotasks();
+
+    expect(pipe.transform('img-1')).toBe('blob:local');
+    expect(createObjectURL).toHaveBeenCalledWith(localBlob);
+  });
+
+  it('returns the files API URL when IndexedDB has no blob', async () => {
+    imageService.getImageRecord.mockResolvedValue(undefined);
+
+    pipe.transform('img-1', 80);
+    await flushMicrotasks();
+
+    expect(pipe.transform('img-1', 80)).toBe('/api/files/image/img-1?width=80');
+  });
+
+  it('does not start a second load for the same id', async () => {
+    imageService.getImageRecord.mockResolvedValue({
+      id: 'img-1',
+      blob: localBlob,
+      uploaded: false,
+    });
+
+    pipe.transform('img-1');
+    pipe.transform('img-1');
+    await flushMicrotasks();
+
+    expect(imageService.getImageRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a stale load when the id changes before IndexedDB answers', async () => {
+    let resolveFirst: (value: unknown) => void = () => undefined;
+    imageService.getImageRecord
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockResolvedValue({ id: 'img-2', blob: otherBlob, uploaded: true });
+
+    pipe.transform('img-1');
+    pipe.transform('img-2');
+    resolveFirst({ id: 'img-1', blob: localBlob, uploaded: true });
+    await flushMicrotasks();
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledWith(otherBlob);
+    expect(pipe.transform('img-2')).toBe('blob:other');
+  });
+
+  it('clears src when IndexedDB lookup fails', async () => {
+    imageService.getImageRecord.mockRejectedValue(new Error('db'));
+
+    pipe.transform('img-1');
+    await flushMicrotasks();
+
+    expect(pipe.transform('img-1')).toBeNull();
+  });
+
+  it('revokes the object URL on destroy', async () => {
+    imageService.getImageRecord.mockResolvedValue({
+      id: 'img-1',
+      blob: localBlob,
+      uploaded: true,
+    });
+    pipe.transform('img-1');
+    await flushMicrotasks();
+
+    pipe.ngOnDestroy();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:local');
+  });
+});

--- a/frontend/tests/unit/services/google-oauth-consent.service.spec.ts
+++ b/frontend/tests/unit/services/google-oauth-consent.service.spec.ts
@@ -1,5 +1,6 @@
 import {
   GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY,
+  GOOGLE_FORCE_CONSENT_COOLDOWN_MS,
   GOOGLE_OAUTH_FORCE_CONSENT_URL,
 } from 'src/app/shared/constants/google-oauth.const';
 import { GoogleOAuthConsentService } from 'src/app/shared/services/integrations/google-oauth-consent.service';
@@ -7,10 +8,13 @@ import { GoogleOAuthConsentService } from 'src/app/shared/services/integrations/
 describe('GoogleOAuthConsentService', () => {
   let service: GoogleOAuthConsentService;
   let assign: jest.Mock;
+  let now: number;
 
   beforeEach(() => {
     sessionStorage.clear();
     assign = jest.fn();
+    now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: { assign },
@@ -20,15 +24,31 @@ describe('GoogleOAuthConsentService', () => {
 
   afterEach(() => {
     sessionStorage.clear();
+    jest.restoreAllMocks();
   });
 
-  it('assigns the force-consent URL once per session', () => {
+  it('assigns the force-consent URL once within the cooldown', () => {
     service.openForceConsentScreen();
     service.openForceConsentScreen();
 
     expect(assign).toHaveBeenCalledTimes(1);
     expect(assign).toHaveBeenCalledWith(GOOGLE_OAUTH_FORCE_CONSENT_URL);
-    expect(sessionStorage.getItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY)).toBe('1');
+    expect(sessionStorage.getItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY)).toBe(String(now));
+  });
+
+  it('retries after the cooldown', () => {
+    service.openForceConsentScreen();
+    (Date.now as jest.Mock).mockReturnValue(now + GOOGLE_FORCE_CONSENT_COOLDOWN_MS + 1);
+    service.openForceConsentScreen();
+
+    expect(assign).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries when the old boolean session flag is still set', () => {
+    sessionStorage.setItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY, '1');
+    service.openForceConsentScreen();
+
+    expect(assign).toHaveBeenCalledTimes(1);
   });
 
   it('allows another redirect after a successful reconnect', () => {
@@ -37,6 +57,6 @@ describe('GoogleOAuthConsentService', () => {
     service.openForceConsentScreen();
 
     expect(assign).toHaveBeenCalledTimes(2);
-    expect(sessionStorage.getItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY)).toBe('1');
+    expect(sessionStorage.getItem(GOOGLE_FORCE_CONSENT_ATTEMPT_STORAGE_KEY)).toBe(String(now));
   });
 });

--- a/frontend/tests/unit/services/http-interceptor.service.spec.ts
+++ b/frontend/tests/unit/services/http-interceptor.service.spec.ts
@@ -1,0 +1,88 @@
+import {
+  HTTP_INTERCEPTORS,
+  HttpClient,
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { Store } from '@ngxs/store';
+import { EGetImageUseCaseError, EUploadImageUseCaseError } from '@brainassistant/contracts';
+import { firstValueFrom } from 'rxjs';
+import { HttpInterceptorService } from 'src/app/shared/services/infrastructure/http-interceptor.service';
+import { AppAction } from 'src/app/shared/state/app.actions';
+
+describe('HttpInterceptorService', () => {
+  let http: HttpClient;
+  let httpTesting: HttpTestingController;
+  let store: { dispatch: jest.Mock };
+
+  beforeEach(() => {
+    store = { dispatch: jest.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        { provide: Store, useValue: store },
+        { provide: Router, useValue: {} },
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: HttpInterceptorService,
+          multi: true,
+        },
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('dispatches GoogleRefreshTokenInvalid on upload 403 JSON', async () => {
+    const pending = firstValueFrom(http.post('/api/files/image', new FormData()));
+    const req = httpTesting.expectOne('/api/files/image');
+    req.flush(
+      {
+        name: EUploadImageUseCaseError.GoogleRefreshTokenInvalid,
+        message: 'Google refresh token is invalid or revoked',
+      },
+      { status: 403, statusText: 'Forbidden' },
+    );
+
+    await expect(pending).rejects.toBeTruthy();
+    expect(store.dispatch).toHaveBeenCalledWith(expect.any(AppAction.GoogleRefreshTokenInvalid));
+  });
+
+  it('dispatches GoogleRefreshTokenInvalid when a blob GET returns JSON 403', async () => {
+    const pending = firstValueFrom(http.get('/api/files/image/img-1', { responseType: 'blob' }));
+    const req = httpTesting.expectOne('/api/files/image/img-1');
+    const body = new Blob(
+      [
+        JSON.stringify({
+          name: EGetImageUseCaseError.GoogleRefreshTokenInvalid,
+          message: 'Google refresh token is invalid or revoked',
+        }),
+      ],
+      { type: 'application/json' },
+    );
+    req.flush(body, { status: 403, statusText: 'Forbidden' });
+
+    await expect(pending).rejects.toBeTruthy();
+    expect(store.dispatch).toHaveBeenCalledWith(expect.any(AppAction.GoogleRefreshTokenInvalid));
+  });
+
+  it('dispatches UserNotAuthenticated on 401', async () => {
+    const pending = firstValueFrom(http.get('/api/sync/changes'));
+    const req = httpTesting.expectOne('/api/sync/changes');
+    req.flush(
+      { name: 'UNEXPECTED_ERROR', message: 'Unauthorized' },
+      { status: 401, statusText: 'Unauthorized' },
+    );
+
+    await expect(pending).rejects.toBeTruthy();
+    expect(store.dispatch).toHaveBeenCalledWith(AppAction.UserNotAuthenticated);
+  });
+});

--- a/frontend/tests/unit/services/image.service.spec.ts
+++ b/frontend/tests/unit/services/image.service.spec.ts
@@ -1,0 +1,72 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngxs/store';
+import { throwError } from 'rxjs';
+import { EUploadImageUseCaseError } from '@brainassistant/contracts';
+import { ImageUploaderService } from 'src/app/shared/services/api/image-uploader.service';
+import { ImageService } from 'src/app/shared/services/application/image.service';
+import { UuidGeneratorService } from 'src/app/shared/services/adapters/uuid-generator.service';
+import { ImageDbService } from 'src/app/shared/services/infrastructure/image-db.service';
+import { FetchService } from 'src/app/shared/services/infrastructure/fetch.service';
+import { ImageOptimizerService } from 'src/app/shared/services/utility/image-optimizer.service';
+import { AppAction } from 'src/app/shared/state/app.actions';
+
+describe('ImageService', () => {
+  let imageDbService: { getAllUnuploadedImages: jest.Mock; updateImage: jest.Mock };
+  let imageUploaderService: { uploadImageBlob: jest.Mock };
+  let http: { get: jest.Mock };
+  let store: { dispatch: jest.Mock };
+  let service: ImageService;
+
+  beforeEach(() => {
+    imageDbService = {
+      getAllUnuploadedImages: jest.fn(),
+      updateImage: jest.fn(),
+    };
+    imageUploaderService = { uploadImageBlob: jest.fn() };
+    http = { get: jest.fn(() => throwError(() => new HttpErrorResponse({ status: 403 }))) };
+    store = { dispatch: jest.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ImageService,
+        { provide: ImageDbService, useValue: imageDbService },
+        { provide: ImageUploaderService, useValue: imageUploaderService },
+        { provide: ImageOptimizerService, useValue: {} },
+        { provide: FetchService, useValue: {} },
+        { provide: UuidGeneratorService, useValue: {} },
+        { provide: Store, useValue: store },
+        { provide: HttpClient, useValue: http },
+      ],
+    });
+    service = TestBed.inject(ImageService);
+  });
+
+  it('dispatches GoogleRefreshTokenInvalid when upload returns that 403', async () => {
+    imageDbService.getAllUnuploadedImages.mockResolvedValue([
+      { id: 'img-1', blob: new Blob(['x']), uploaded: false },
+    ]);
+    imageUploaderService.uploadImageBlob.mockRejectedValue(
+      new HttpErrorResponse({
+        status: 403,
+        error: {
+          name: EUploadImageUseCaseError.GoogleRefreshTokenInvalid,
+          message: 'Google refresh token is invalid or revoked',
+        },
+      }),
+    );
+
+    await service.uploadImages();
+
+    expect(store.dispatch).toHaveBeenCalledWith(expect.any(AppAction.GoogleRefreshTokenInvalid));
+    expect(imageDbService.updateImage).not.toHaveBeenCalled();
+  });
+
+  it('probes the files API only once when several thumbnails fail', () => {
+    service.probeRemoteImage('img-1');
+    service.probeRemoteImage('img-2');
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(http.get).toHaveBeenCalledWith('/api/files/image/img-1', { responseType: 'blob' });
+  });
+});


### PR DESCRIPTION
## Summary
- After #141, some devices still did not open Google force-consent: a duplicate `provideHttpClient()` could skip the interceptor, JSON 403s as blobs were not unwrapped, and a one-shot `sessionStorage` flag blocked all later retries.
- Invalid Drive refresh-token errors now dispatch reconsent, navigate to `/api/integrations/google/oauth-consent-screen?forceConsent=1`, and use a 60s cooldown instead of a permanent one-shot.
- Thumbnails still load via `<img src>`. On a remote image error, one HttpClient probe per session is enough for the interceptor to see the 403.

## Test plan
- [ ] Revoke Google Drive access, then open a task with a Drive image — the app should navigate to Google consent, not stay on the current screen.
- [ ] Cancel or fail that consent once; after 60s a later 403 should try force-consent again (legacy `sessionStorage` value `1` should not block it).
- [ ] Task tiles and task view still show cached/local images as blob URLs and remote images as `/api/files/image/:id` (not a full HttpClient download per thumbnail).
- [ ] Uploading an image with an invalid refresh token still triggers the same reconsent path.
- [ ] Frontend unit tests for the interceptor, consent cooldown, image probe, and `ImageSrcPipe`.

Made with [Cursor](https://cursor.com)