### PR TITLE
chore(docker): cache npm installs and slim the prod backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,13 +11,15 @@ RUN apt-get update \
 # Copy contracts and build
 COPY contracts/ ./contracts/
 WORKDIR /app/contracts
-RUN --mount=type=cache,id=npm,target=/root/.npm npm install && npm run build
+RUN --mount=type=cache,id=npm,target=/root/.npm npm ci --ignore-scripts && npm run build
 
 # Copy backend and install dependencies (including linked contracts)
 WORKDIR /app/backend
 COPY backend/ .
-RUN --mount=type=cache,id=npm,target=/root/.npm npm install --verbose
-RUN --mount=type=cache,id=npm,target=/root/.npm npm install -g nodemon
+RUN --mount=type=cache,id=npm,target=/root/.npm \
+  npm ci --ignore-scripts \
+  && npm rebuild sharp \
+  && npm install -g nodemon --ignore-scripts
 
 RUN chown -R node:node /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,8 +18,7 @@ WORKDIR /app/backend
 COPY backend/ .
 RUN --mount=type=cache,id=npm,target=/root/.npm \
   npm ci --ignore-scripts \
-  && npm rebuild sharp \
-  && npm install -g nodemon --ignore-scripts
+  && npm rebuild sharp
 
 RUN chown -R node:node /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:24
 
 WORKDIR /app
@@ -10,13 +11,13 @@ RUN apt-get update \
 # Copy contracts and build
 COPY contracts/ ./contracts/
 WORKDIR /app/contracts
-RUN npm install && npm run build
+RUN --mount=type=cache,id=npm,target=/root/.npm npm install && npm run build
 
 # Copy backend and install dependencies (including linked contracts)
 WORKDIR /app/backend
 COPY backend/ .
-RUN npm install --verbose
-RUN npm install -g nodemon
+RUN --mount=type=cache,id=npm,target=/root/.npm npm install --verbose
+RUN --mount=type=cache,id=npm,target=/root/.npm npm install -g nodemon
 
 RUN chown -R node:node /app
 

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -10,12 +10,13 @@ ENV MONGOMS_DISABLE_POSTINSTALL=1
 
 COPY contracts/ ../contracts/
 WORKDIR /usr/src/contracts
-RUN --mount=type=cache,id=npm,target=/root/.npm npm ci
+RUN --mount=type=cache,id=npm,target=/root/.npm npm ci --ignore-scripts
 RUN npm run build
 
 WORKDIR /usr/src/app
 COPY backend/package*.json ./
-RUN --mount=type=cache,id=npm,target=/root/.npm npm ci
+RUN --mount=type=cache,id=npm,target=/root/.npm npm ci --ignore-scripts \
+  && npm rebuild sharp
 
 COPY backend/ .
 

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,4 +1,30 @@
-FROM node:24
+# syntax=docker/dockerfile:1
+# Build compiles with the full tree (TypeScript + test/lint). Runtime copies only
+# production node_modules + dist. Same node:24 so native addons (sharp) match.
+FROM node:24 AS builder
+
+WORKDIR /usr/src/app
+
+# mongodb-memory-server is a devDependency; do not download its MongoDB binary.
+ENV MONGOMS_DISABLE_POSTINSTALL=1
+
+COPY contracts/ ../contracts/
+WORKDIR /usr/src/contracts
+RUN --mount=type=cache,id=npm,target=/root/.npm npm ci
+RUN npm run build
+
+WORKDIR /usr/src/app
+COPY backend/package*.json ./
+RUN --mount=type=cache,id=npm,target=/root/.npm npm ci
+
+COPY backend/ .
+
+ARG TSC_MAX_OLD_SPACE_MB=4096
+RUN NODE_OPTIONS="--max-old-space-size=${TSC_MAX_OLD_SPACE_MB}" ./node_modules/.bin/tsc -p tsconfig.prod.json \
+  && npm prune --omit=dev \
+  && rm -rf /usr/src/contracts/node_modules
+
+FROM node:24 AS runtime
 
 WORKDIR /usr/src/app
 
@@ -7,28 +33,18 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends libvips42 gosu \
   && rm -rf /var/lib/apt/lists/*
 
-# Copy contracts package first
-COPY contracts/ ../contracts/
-WORKDIR /usr/src/contracts
-RUN npm ci
-RUN npm run build
-
-# Build backend
-WORKDIR /usr/src/app
-COPY backend/package*.json ./
-RUN npm ci --verbose
-
-COPY backend/ .
-
-# Image is built on a developer machine / CI, then pulled on the VDS.
-ARG TSC_MAX_OLD_SPACE_MB=4096
-RUN NODE_OPTIONS="--max-old-space-size=${TSC_MAX_OLD_SPACE_MB}" ./node_modules/.bin/tsc -p tsconfig.prod.json \
-  && chown -R node:node /usr/src/app /usr/src/contracts
+# file:../contracts is a symlink into /usr/src/contracts — copy both trees.
+COPY --from=builder /usr/src/app/package.json ./
+COPY --from=builder /usr/src/app/node_modules ./node_modules
+COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/contracts/package.json /usr/src/contracts/package.json
+COPY --from=builder /usr/src/contracts/dist /usr/src/contracts/dist
 
 COPY backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # Strip CRLF if the file was saved on Windows (fixes: /usr/bin/env: 'sh\r': No such file)
 RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh \
-  && chmod +x /usr/local/bin/docker-entrypoint.sh
+  && chmod +x /usr/local/bin/docker-entrypoint.sh \
+  && chown -R node:node /usr/src/app /usr/src/contracts
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 # Image default is node (docker:S6471). production.yml sets user: "0" so the

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -69,6 +69,7 @@
         "jest": "^29.7.0",
         "knip": "^6.34.0",
         "mongodb-memory-server": "^10.1.2",
+        "nodemon": "^3.1.14",
         "passport-strategy": "^1.0.0",
         "prettier": "^3.5.3",
         "supertest": "^7.0.0",
@@ -1035,9 +1036,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1053,9 +1051,6 @@
       "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1073,9 +1068,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1091,9 +1083,6 @@
       "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1111,9 +1100,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1129,9 +1115,6 @@
       "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1149,9 +1132,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1168,9 +1148,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1186,9 +1163,6 @@
       "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1212,9 +1186,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1236,9 +1207,6 @@
       "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1262,9 +1230,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1286,9 +1251,6 @@
       "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1312,9 +1274,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1337,9 +1296,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1361,9 +1317,6 @@
       "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4862,6 +4815,19 @@
         "node": "*"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -5222,6 +5188,31 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/ci-info": {
@@ -8085,6 +8076,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8221,6 +8219,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -10319,6 +10330,97 @@
         "node": ">=18"
       }
     },
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/nodemon/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -11199,6 +11301,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11331,6 +11440,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11972,6 +12094,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -12550,6 +12685,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/tr46": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
@@ -12969,6 +13114,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -77,6 +77,7 @@
     "jest": "^29.7.0",
     "knip": "^6.34.0",
     "mongodb-memory-server": "^10.1.2",
+    "nodemon": "^3.1.14",
     "passport-strategy": "^1.0.0",
     "prettier": "^3.5.3",
     "supertest": "^7.0.0",

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 # Copy contracts package first
 COPY contracts/ ../contracts/
 WORKDIR /usr/src/contracts
-RUN --mount=type=cache,id=npm,target=/root/.npm npm install --no-audit --no-fund
+RUN --mount=type=cache,id=npm,target=/root/.npm npm ci --ignore-scripts --no-audit --no-fund
 RUN npm run build
 
 # Build frontend (do not rely on host node_modules — see repo .dockerignore)
@@ -14,7 +14,7 @@ WORKDIR /usr/src/app
 
 # Install deps with good layer caching: only re-run when manifests change.
 COPY frontend/package*.json ./
-RUN --mount=type=cache,id=npm,target=/root/.npm npm install --no-audit --no-fund
+RUN --mount=type=cache,id=npm,target=/root/.npm npm ci --ignore-scripts --no-audit --no-fund
 
 # Copy the rest of the frontend sources.
 COPY frontend/ .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:24
 
 WORKDIR /usr/src/app
@@ -5,7 +6,7 @@ WORKDIR /usr/src/app
 # Copy contracts package first
 COPY contracts/ ../contracts/
 WORKDIR /usr/src/contracts
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,id=npm,target=/root/.npm npm install --no-audit --no-fund
 RUN npm run build
 
 # Build frontend (do not rely on host node_modules — see repo .dockerignore)
@@ -13,7 +14,7 @@ WORKDIR /usr/src/app
 
 # Install deps with good layer caching: only re-run when manifests change.
 COPY frontend/package*.json ./
-RUN npm install --no-audit --no-fund
+RUN --mount=type=cache,id=npm,target=/root/.npm npm install --no-audit --no-fund
 
 # Copy the rest of the frontend sources.
 COPY frontend/ .


### PR DESCRIPTION
## Summary
- Cache npm installs in the backend and frontend Dockerfiles with BuildKit (`--mount=type=cache,id=npm`).
- Split the production backend image into a builder stage and a runtime stage so the VDS image ships `dist` + production `node_modules`, not TypeScript sources or test/dev tooling.
- Skip mongodb-memory-server's postinstall download during the image build (`MONGOMS_DISABLE_POSTINSTALL=1`).

## Test plan
- [ ] `docker compose build` (dev) rebuilds backend/frontend and reuses the npm cache on a second build.
- [ ] `docker compose -f production.yml build` produces a backend image that starts and serves the API.
- [ ] Prod backend container still resizes images (sharp / libvips) and runs the entrypoint as before.
- [ ] Image size of the prod backend is smaller than the previous single-stage build.
