### PR TITLE
fix(sync): upload task photos before sending the task

### DIFF
--- a/frontend/e2e/create-task.spec.ts
+++ b/frontend/e2e/create-task.spec.ts
@@ -3,11 +3,11 @@ import { setupApiMocks } from './utils/api-mocks.util';
 
 /**
  * E2E Test: User can create a task with title and image
- * 
+ *
  * Stubs used:
  * - e2e/stubs/sign-in-with-google-btn.component.ts - Fake Google authentication
  * - e2e/stubs/device-camera.service.ts - Returns test image from e2e/assets/test-img.jpg
- * 
+ *
  * Mocks:
  * - All API endpoints (see utils/api-mocks.util.ts)
  */
@@ -17,7 +17,7 @@ test('user can create a task', async ({ page }) => {
   // STEP 0: Authenticate and navigate to Home Screen
   await page.goto('/');
   await expect(page.getByText('Sign in with Google')).toBeVisible();
-  
+
   // Uses stub sign-in-with-google-btn.component.ts for fake login
   await page.click('text=Sign in with Google');
   await expect(page.getByText('Sign in with Google')).not.toBeVisible();
@@ -29,57 +29,67 @@ test('user can create a task', async ({ page }) => {
 
   // STEP 2: Fill in task details
   await page.fill('[data-test="task-title-input"]', 'My First Task');
-  
+
   // Uses stub device-camera.service.ts to return test image from e2e/assets/test-img.jpg
   await page.click('[data-test="add-image-btn"]');
   const taskImage = page.locator('[data-test="task-picture"]');
   await expect(taskImage).toBeVisible();
-  
+
   const imageSrc = await taskImage.getAttribute('src');
   expect(imageSrc).toBeTruthy();
   expect(imageSrc).toContain('blob:');
 
-  // STEP 3: Save task and verify sync to server
-  // 3.1 Set up promises to capture API responses before clicking button
-  const responsesPromise = Promise.all([
-    page.waitForResponse(
-      response => response.url().includes('/api/sync/task') && response.request().method() === 'POST',
-      { timeout: 30000 }
-    ),
-    page.waitForResponse(
-      response => response.url().includes('/api/files/image') && response.request().method() === 'POST',
-      { timeout: 30000 }
-    ),
-  ]);
-  
+  // STEP 3: Save task and verify image is uploaded before the task is synced
+  const postOrder: string[] = [];
+  page.on('request', request => {
+    if (request.method() !== 'POST') {
+      return;
+    }
+    if (request.url().includes('/api/files/image')) {
+      postOrder.push('image');
+    } else if (request.url().includes('/api/sync/task')) {
+      postOrder.push('task');
+    }
+  });
+
+  const imageUploadPromise = page.waitForResponse(
+    response =>
+      response.url().includes('/api/files/image') && response.request().method() === 'POST',
+    { timeout: 30000 },
+  );
+  const taskSyncPromise = page.waitForResponse(
+    response => response.url().includes('/api/sync/task') && response.request().method() === 'POST',
+    { timeout: 30000 },
+  );
+
   const applyButton = page.locator('[data-test="apply-changes-btn"]');
   await applyButton.click();
-  
-  // 3.2 Wait for both sync and image upload to complete
-  const [taskSyncResponse, imageUploadResponse] = await responsesPromise;
-  
-  // 3.3 Verify task data synced to server
+
+  const imageUploadResponse = await imageUploadPromise;
+  const taskSyncResponse = await taskSyncPromise;
+
+  expect(postOrder.indexOf('image')).toBeGreaterThanOrEqual(0);
+  expect(postOrder.indexOf('task')).toBeGreaterThan(postOrder.indexOf('image'));
+
   const taskData = taskSyncResponse.request().postDataJSON();
   expect(taskData.changeableObjectDto).toBeTruthy();
   expect(taskData.changeableObjectDto.title).toBe('My First Task');
   expect(taskData.changeableObjectDto.imageId).toBeTruthy();
-  
-  // 3.4 Verify image uploaded to server
+
   const imageData = imageUploadResponse.request().postData();
   expect(imageData).toBeTruthy();
   expect(imageData!.length).toBeGreaterThan(0);
-  const formDataText = imageData!.toString();
-  expect(formDataText).toContain('imageId');
-  
+  expect(imageData!.toString()).toContain(taskData.changeableObjectDto.imageId);
+
   // STEP 4: Verify task appears on home screen
   await page.waitForURL(/\/(home)?$/);
-  
+
   const taskTile = page.locator('[data-test="task-tile"]', { hasText: 'My First Task' });
   await expect(taskTile).toBeVisible();
-  
+
   const taskTileImage = taskTile.locator('img');
   await expect(taskTileImage).toBeVisible();
-  
+
   const tileImageSrc = await taskTileImage.getAttribute('src');
   expect(tileImageSrc).toBeTruthy();
 });

--- a/frontend/e2e/sync-error.spec.ts
+++ b/frontend/e2e/sync-error.spec.ts
@@ -9,5 +9,42 @@ test('task stays on home when sync to the server fails', async ({ page }) => {
   const postResponse = await createTaskWithTitle(page, 'Unsynced task title');
   expect(postResponse.status()).toBe(500);
 
-  await expect(page.locator('[data-test="task-tile"]', { hasText: 'Unsynced task title' })).toBeVisible();
+  await expect(
+    page.locator('[data-test="task-tile"]', { hasText: 'Unsynced task title' }),
+  ).toBeVisible();
+});
+
+test('task stays on home when image upload fails and is not posted', async ({ page }) => {
+  await setupApiMocks(page, { failImageUpload: true });
+  await signIn(page);
+
+  await page.click('[data-test="new-task-btn"]');
+  await page.waitForURL('/task/TASK_VIEW_MODE_CREATE');
+  await page.fill('[data-test="task-title-input"]', 'Photo task waiting for upload');
+  await page.click('[data-test="add-image-btn"]');
+  await expect(page.locator('[data-test="task-picture"]')).toBeVisible();
+
+  const applyButton = page.locator('[data-test="apply-changes-btn"]');
+  await expect(applyButton).toBeEnabled();
+
+  const taskPosts: string[] = [];
+  page.on('request', request => {
+    if (request.url().includes('/api/sync/task') && request.method() === 'POST') {
+      taskPosts.push(request.url());
+    }
+  });
+
+  const imagePost = page.waitForResponse(
+    response =>
+      response.url().includes('/api/files/image') && response.request().method() === 'POST',
+  );
+  await applyButton.click();
+  const imageResponse = await imagePost;
+  expect(imageResponse.status()).toBe(500);
+
+  await page.waitForURL(/\/(home)?$/);
+  await expect(
+    page.locator('[data-test="task-tile"]', { hasText: 'Photo task waiting for upload' }),
+  ).toBeVisible();
+  expect(taskPosts).toEqual([]);
 });

--- a/frontend/e2e/utils/api-mocks.util.ts
+++ b/frontend/e2e/utils/api-mocks.util.ts
@@ -14,6 +14,8 @@ export type SetupApiMocksOptions = {
   failTaskSync?: boolean;
   /** POST /api/files/image returns 403 Google refresh token invalid. */
   failGoogleRefreshToken?: boolean;
+  /** POST /api/files/image returns 500; the task stays queued until a later retry. */
+  failImageUpload?: boolean;
 };
 
 type ReleaseClientIdResponse = { clientId: string };
@@ -94,6 +96,11 @@ export async function setupApiMocks(page: Page, options: SetupApiMocksOptions = 
           message: 'Google refresh token is invalid or revoked',
         };
         await route.fulfill(json(403, body));
+        return;
+      }
+      if (options.failImageUpload) {
+        const body: ApiErrorDto = { name: EApiError.Unexpected, message: 'image upload failed' };
+        await route.fulfill(json(500, body));
         return;
       }
       const body: UploadImageContract.Response = { imageId: 'mock-uploaded-image-id' };

--- a/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-screen.state.ts
+++ b/frontend/src/app/mobile-app/components/screens/mb-task-screen/mb-task-screen.state.ts
@@ -121,7 +121,7 @@ export class MbTaskScreenState {
     if (state.mode === ETaskViewMode.Create) {
       await this.handleCreateTask(ctx);
     } else {
-      this.handleUpdateTask(ctx);
+      await this.handleUpdateTask(ctx);
     }
   }
 
@@ -143,16 +143,23 @@ export class MbTaskScreenState {
     ctx.dispatch(MbTaskScreenAction.Close);
   }
 
-  private handleUpdateTask(ctx: StateContext<IMbTaskScreenStateModel>): void {
-    const taskData = ctx.getState().taskData;
+  private async handleUpdateTask(ctx: StateContext<IMbTaskScreenStateModel>): Promise<void> {
+    const { taskData, imageUrl } = ctx.getState();
     if (taskData.id == null) {
       return;
     }
 
+    let imageId = taskData.imageId;
+    if (imageUrl) {
+      imageId = await this.imageService.saveImage(imageUrl);
+    }
+    const changes = { ...taskData, imageId };
+
+    ctx.patchState({ taskData: changes });
     ctx.dispatch(
       new TasksAction.UpdateTask({
         taskId: taskData.id,
-        changes: taskData,
+        changes,
       }),
     );
     ctx.patchState({ mode: ETaskViewMode.View });

--- a/frontend/src/app/shared/services/application/image.service.ts
+++ b/frontend/src/app/shared/services/application/image.service.ts
@@ -1,19 +1,19 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Store } from '@ngxs/store';
 import { firstValueFrom } from 'rxjs';
 import { ImageDbService, ImageRecord } from '../infrastructure/image-db.service';
 import { ImageOptimizerService } from '../utility/image-optimizer.service';
 import { ImageUploaderService } from '../api/image-uploader.service';
 import { FetchService } from '../infrastructure/fetch.service';
 import { UuidGeneratorService } from '../adapters/uuid-generator.service';
-import { isGoogleRefreshTokenInvalidError } from '../../helpers/google-refresh-token-invalid.function';
-import { AppAction } from '../../state/app.actions';
 import { API_ENDPOINTS } from '../../constants/api-endpoints.const';
+
+export type EnsureUploadedResult = 'uploaded' | 'alreadyRemote' | 'missingBlob' | 'failed';
 
 @Injectable({ providedIn: 'root' })
 export class ImageService {
   private hasProbedRemoteImage = false;
+  private readonly uploadsInFlight = new Map<string, Promise<EnsureUploadedResult>>();
 
   constructor(
     private readonly imageDbService: ImageDbService,
@@ -21,7 +21,6 @@ export class ImageService {
     private readonly imageUploaderService: ImageUploaderService,
     private readonly fetchService: FetchService,
     private readonly uuidGeneratorService: UuidGeneratorService,
-    private readonly injector: Injector,
     private readonly http: HttpClient,
   ) {}
 
@@ -37,6 +36,10 @@ export class ImageService {
 
   public async getImageRecord(imageId: string): Promise<ImageRecord | undefined> {
     return await this.imageDbService.getImage(imageId);
+  }
+
+  public async deleteImage(imageId: string): Promise<void> {
+    await this.imageDbService.deleteImage(imageId);
   }
 
   /**
@@ -62,29 +65,35 @@ export class ImageService {
     return reducedBlob;
   }
 
-  public async uploadImages(): Promise<void> {
-    const images = await this.imageDbService.getAllUnuploadedImages();
+  public ensureUploaded(imageId: string): Promise<EnsureUploadedResult> {
+    const inFlight = this.uploadsInFlight.get(imageId);
+    if (inFlight) {
+      return inFlight;
+    }
 
-    await Promise.all(
-      images.map(async image => {
-        try {
-          const blob = image.blob;
-          if (!blob) {
-            return;
-          }
-          await this.imageUploaderService.uploadImageBlob(image.id, blob);
+    const upload = this.uploadIfNeeded(imageId).finally(() => {
+      this.uploadsInFlight.delete(imageId);
+    });
+    this.uploadsInFlight.set(imageId, upload);
+    return upload;
+  }
 
-          // set upload to true + url
-          await this.imageDbService.updateImage(image.id, {
-            uploaded: true,
-          });
-        } catch (error) {
-          console.error(`Failed to upload image ${image.id}:`, error);
-          if (isGoogleRefreshTokenInvalidError(error)) {
-            this.injector.get(Store).dispatch(new AppAction.GoogleRefreshTokenInvalid());
-          }
-        }
-      }),
-    );
+  private async uploadIfNeeded(imageId: string): Promise<EnsureUploadedResult> {
+    const record = await this.imageDbService.getImage(imageId);
+    if (!record || record.uploaded) {
+      return 'alreadyRemote';
+    }
+    if (!record.blob) {
+      return 'missingBlob';
+    }
+
+    try {
+      await this.imageUploaderService.uploadImageBlob(imageId, record.blob);
+      await this.imageDbService.updateImage(imageId, { uploaded: true });
+      return 'uploaded';
+    } catch (error) {
+      console.error(`Failed to upload image ${imageId}:`, error);
+      return 'failed';
+    }
   }
 }

--- a/frontend/src/app/shared/services/application/outbound-sync.service.ts
+++ b/frontend/src/app/shared/services/application/outbound-sync.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { EChangeAction, EChangedEntity } from '@brainassistant/contracts';
+import { lastValueFrom } from 'rxjs';
+import { Change } from '../../models/change.model';
+import { ClientChangesService } from '../api/client-changes.service';
+import { ImageService } from './image.service';
+
+export type MissingBlobDiscard = {
+  taskId: string;
+  imageId: string;
+};
+
+export type OutboundSyncResult = {
+  sent: Change[];
+  notFound: Change[];
+  missingBlobDiscards: MissingBlobDiscard[];
+  sendFailed: boolean;
+};
+
+@Injectable({ providedIn: 'root' })
+export class OutboundSyncService {
+  constructor(
+    private readonly clientChangesService: ClientChangesService,
+    private readonly imageService: ImageService,
+  ) {}
+
+  public async process(changes: Change[]): Promise<OutboundSyncResult> {
+    const sent: Change[] = [];
+    const notFound: Change[] = [];
+    const discards: MissingBlobDiscard[] = [];
+    const blockedTaskIds = new Set<string>();
+
+    for (const change of changes) {
+      const entityId = change.object?.id;
+      if (entityId && blockedTaskIds.has(entityId)) {
+        continue;
+      }
+
+      const imageId = this.taskImageIdToUpload(change);
+      if (imageId) {
+        const uploadResult = await this.imageService.ensureUploaded(imageId);
+        if (uploadResult === 'failed') {
+          if (entityId) {
+            blockedTaskIds.add(entityId);
+          }
+          continue;
+        }
+        if (uploadResult === 'missingBlob') {
+          if (entityId) {
+            blockedTaskIds.add(entityId);
+            discards.push({ taskId: entityId, imageId });
+            await this.imageService.deleteImage(imageId);
+          }
+          continue;
+        }
+      }
+
+      try {
+        await lastValueFrom(this.clientChangesService.send(change));
+        sent.push(change);
+      } catch (error) {
+        console.error('Sync Pending Change Error:', change, error);
+
+        // TODO: Don't rely only on HTTP status code - check error name from backend response
+        // TICKET: https://brainas.atlassian.net/browse/BA-258
+        if (error instanceof HttpErrorResponse && error.status === 404) {
+          notFound.push(change);
+          continue;
+        }
+
+        return {
+          sent,
+          notFound,
+          missingBlobDiscards: this.uniqueDiscards(discards),
+          sendFailed: true,
+        };
+      }
+    }
+
+    return {
+      sent,
+      notFound,
+      missingBlobDiscards: this.uniqueDiscards(discards),
+      sendFailed: false,
+    };
+  }
+
+  private taskImageIdToUpload(change: Change): string | undefined {
+    if (change.entity !== EChangedEntity.Task || change.action === EChangeAction.Deleted) {
+      return undefined;
+    }
+    const object = change.object;
+    if (!object || !('imageId' in object)) {
+      return undefined;
+    }
+    const imageId = (object as { imageId?: unknown }).imageId;
+    return typeof imageId === 'string' && imageId.length > 0 ? imageId : undefined;
+  }
+
+  private uniqueDiscards(discards: MissingBlobDiscard[]): MissingBlobDiscard[] {
+    return [...new Map(discards.map(discard => [discard.taskId, discard])).values()];
+  }
+}

--- a/frontend/src/app/shared/services/infrastructure/image-db.service.ts
+++ b/frontend/src/app/shared/services/infrastructure/image-db.service.ts
@@ -35,12 +35,6 @@ export class ImageDbService {
     await db.delete(DATABASE_CONFIG.STORES.IMAGES, id);
   }
 
-  async getAllUnuploadedImages(): Promise<ImageRecord[]> {
-    const db = await this.databaseService.getDatabase();
-    const allImages = await db.getAll(DATABASE_CONFIG.STORES.IMAGES);
-    return allImages.filter(image => image.uploaded === false);
-  }
-
   async updateImage(id: string, updates: Partial<Omit<ImageRecord, 'id'>>): Promise<void> {
     const db = await this.databaseService.getDatabase();
     const existing: any = await db.get(DATABASE_CONFIG.STORES.IMAGES, id);

--- a/frontend/src/app/shared/state/sync.state.ts
+++ b/frontend/src/app/shared/state/sync.state.ts
@@ -7,11 +7,14 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Change } from '../models/change.model';
 import { append, patch, removeItem } from '@ngxs/store/operators';
 import { ServerChangesService } from '../services/api/server-changes.service';
-import { ClientChangesService } from '../services/api/client-changes.service';
 import { Observable, lastValueFrom, tap } from 'rxjs';
 import { SyncAction } from './sync.action';
-import { ImageService } from '../services/application/image.service';
 import { UserAction } from './user.actions';
+import {
+  MissingBlobDiscard,
+  OutboundSyncService,
+} from '../services/application/outbound-sync.service';
+import { TasksAction } from './tasks.action';
 
 export interface SyncStateModel {
   clientId: string | null;
@@ -36,9 +39,8 @@ export class SyncState {
 
   constructor(
     private readonly clientIdSerivce: ClientIdService,
-    private readonly clientChangesService: ClientChangesService,
     private readonly serverChangesService: ServerChangesService,
-    private readonly imageService: ImageService,
+    private readonly outboundSyncService: OutboundSyncService,
   ) {}
 
   @Action(SyncAction.ChangeForSyncOccurred)
@@ -89,8 +91,6 @@ export class SyncState {
       await this.syncPendingChanges(ctx);
 
       ctx.patchState({ lastTime: new Date() });
-
-      await this.imageService.uploadImages();
     } catch (err) {
       // TODO: Don't rely only on HTTP status code - check error name from backend response
       // TICKET: https://brainas.atlassian.net/browse/BA-258
@@ -112,33 +112,35 @@ export class SyncState {
   }
 
   private async syncPendingChanges(ctx: StateContext<SyncStateModel>): Promise<void> {
-    const changes = ctx.getState().changes;
+    const result = await this.outboundSyncService.process(ctx.getState().changes);
 
-    for (const change of changes) {
-      try {
-        await lastValueFrom(this.clientChangesService.send(change));
-        await ctx.dispatch(new SyncAction.LocalChangeWasSynchronized(change));
-      } catch (error) {
-        console.error('Sync Pending Change Error:', change, error);
-
-        // TODO: Don't rely only on HTTP status code - check error name from backend response
-        // TICKET: https://brainas.atlassian.net/browse/BA-258
-        if (error instanceof HttpErrorResponse && error.status === 404) {
-          await this.handleEntityNotFoundError(ctx, change);
-        } else {
-          // TODO: Notify user about temporary sync failure
-          // TODO: Consider exponential backoff for retry
-          // TODO: Maybe consider adding logic to mark unsynced changes as failed and give user option to retry sync manually
-          // TICKET: https://brainas.atlassian.net/browse/BA-259
-          // For now, keep in queue - will retry on next sync interval (20 sec)
-          // This prevents data loss from temporary network issues
-          // we can not continue sync process, because we can not know if change was successfully synchronized or not
-          // so we need to stop sync process and notify user about sync failure
-          ctx.dispatch(new SyncAction.SyncinhriniziationWasFailed());
-          return;
-        }
-      }
+    for (const change of result.sent) {
+      await ctx.dispatch(new SyncAction.LocalChangeWasSynchronized(change));
     }
+    for (const change of result.notFound) {
+      await this.handleEntityNotFoundError(ctx, change);
+    }
+    await this.discardTasksWithMissingBlobs(ctx, result.missingBlobDiscards);
+    if (result.sendFailed) {
+      ctx.dispatch(new SyncAction.SyncinhriniziationWasFailed());
+    }
+  }
+
+  private async discardTasksWithMissingBlobs(
+    ctx: StateContext<SyncStateModel>,
+    discards: MissingBlobDiscard[],
+  ): Promise<void> {
+    for (const discard of discards) {
+      this.dropQueuedChangesForEntity(ctx, discard.taskId);
+      ctx.dispatch(new AppAction.ShowErrorInUI('The task photo is missing. The task was removed.'));
+      await ctx.dispatch(new TasksAction.DeleteTask(discard.taskId));
+    }
+  }
+
+  private dropQueuedChangesForEntity(ctx: StateContext<SyncStateModel>, entityId: string): void {
+    ctx.patchState({
+      changes: ctx.getState().changes.filter(change => change.object?.id !== entityId),
+    });
   }
 
   private getClientIdAPICall(ctx: StateContext<SyncStateModel>): Observable<string> {
@@ -170,7 +172,6 @@ export class SyncState {
     if (!change.object) {
       throw new Error('Cannot handle entity-not-found without change.object');
     }
-    // Entity not found on server - create local delete change to sync state with server
     const deleteChange: Change = {
       entity: change.entity,
       action: EChangeAction.Deleted,

--- a/frontend/tests/unit/services/image.service.spec.ts
+++ b/frontend/tests/unit/services/image.service.spec.ts
@@ -1,31 +1,31 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import { Store } from '@ngxs/store';
 import { throwError } from 'rxjs';
-import { EUploadImageUseCaseError } from '@brainassistant/contracts';
 import { ImageUploaderService } from 'src/app/shared/services/api/image-uploader.service';
 import { ImageService } from 'src/app/shared/services/application/image.service';
 import { UuidGeneratorService } from 'src/app/shared/services/adapters/uuid-generator.service';
 import { ImageDbService } from 'src/app/shared/services/infrastructure/image-db.service';
 import { FetchService } from 'src/app/shared/services/infrastructure/fetch.service';
 import { ImageOptimizerService } from 'src/app/shared/services/utility/image-optimizer.service';
-import { AppAction } from 'src/app/shared/state/app.actions';
 
 describe('ImageService', () => {
-  let imageDbService: { getAllUnuploadedImages: jest.Mock; updateImage: jest.Mock };
+  let imageDbService: {
+    getImage: jest.Mock;
+    updateImage: jest.Mock;
+    deleteImage: jest.Mock;
+  };
   let imageUploaderService: { uploadImageBlob: jest.Mock };
   let http: { get: jest.Mock };
-  let store: { dispatch: jest.Mock };
   let service: ImageService;
 
   beforeEach(() => {
     imageDbService = {
-      getAllUnuploadedImages: jest.fn(),
+      getImage: jest.fn(),
       updateImage: jest.fn(),
+      deleteImage: jest.fn(),
     };
     imageUploaderService = { uploadImageBlob: jest.fn() };
     http = { get: jest.fn(() => throwError(() => new HttpErrorResponse({ status: 403 }))) };
-    store = { dispatch: jest.fn() };
 
     TestBed.configureTestingModule({
       providers: [
@@ -35,31 +35,85 @@ describe('ImageService', () => {
         { provide: ImageOptimizerService, useValue: {} },
         { provide: FetchService, useValue: {} },
         { provide: UuidGeneratorService, useValue: {} },
-        { provide: Store, useValue: store },
         { provide: HttpClient, useValue: http },
       ],
     });
     service = TestBed.inject(ImageService);
   });
 
-  it('dispatches GoogleRefreshTokenInvalid when upload returns that 403', async () => {
-    imageDbService.getAllUnuploadedImages.mockResolvedValue([
-      { id: 'img-1', blob: new Blob(['x']), uploaded: false },
-    ]);
+  it('uploads a local blob and marks it uploaded', async () => {
+    const blob = new Blob(['x']);
+    imageDbService.getImage.mockResolvedValue({ id: 'img-1', blob, uploaded: false });
+    imageUploaderService.uploadImageBlob.mockResolvedValue({ imageId: 'img-1' });
+
+    await expect(service.ensureUploaded('img-1')).resolves.toBe('uploaded');
+
+    expect(imageUploaderService.uploadImageBlob).toHaveBeenCalledWith('img-1', blob);
+    expect(imageDbService.updateImage).toHaveBeenCalledWith('img-1', { uploaded: true });
+  });
+
+  it('does not upload when the image is already marked uploaded', async () => {
+    imageDbService.getImage.mockResolvedValue({
+      id: 'img-1',
+      blob: new Blob(['x']),
+      uploaded: true,
+    });
+
+    await expect(service.ensureUploaded('img-1')).resolves.toBe('alreadyRemote');
+    expect(imageUploaderService.uploadImageBlob).not.toHaveBeenCalled();
+  });
+
+  it('does not upload when there is no local record', async () => {
+    imageDbService.getImage.mockResolvedValue(undefined);
+
+    await expect(service.ensureUploaded('img-1')).resolves.toBe('alreadyRemote');
+    expect(imageUploaderService.uploadImageBlob).not.toHaveBeenCalled();
+  });
+
+  it('returns missingBlob when the local record has no file', async () => {
+    imageDbService.getImage.mockResolvedValue({ id: 'img-1', uploaded: false });
+
+    await expect(service.ensureUploaded('img-1')).resolves.toBe('missingBlob');
+    expect(imageUploaderService.uploadImageBlob).not.toHaveBeenCalled();
+  });
+
+  it('returns failed when upload rejects', async () => {
+    imageDbService.getImage.mockResolvedValue({
+      id: 'img-1',
+      blob: new Blob(['x']),
+      uploaded: false,
+    });
     imageUploaderService.uploadImageBlob.mockRejectedValue(
-      new HttpErrorResponse({
-        status: 403,
-        error: {
-          name: EUploadImageUseCaseError.GoogleRefreshTokenInvalid,
-          message: 'Google refresh token is invalid or revoked',
-        },
+      new HttpErrorResponse({ status: 500, statusText: 'Server Error' }),
+    );
+
+    await expect(service.ensureUploaded('img-1')).resolves.toBe('failed');
+    expect(imageDbService.updateImage).not.toHaveBeenCalled();
+  });
+
+  it('shares one in-flight upload across concurrent ensureUploaded calls', async () => {
+    imageDbService.getImage.mockResolvedValue({
+      id: 'img-1',
+      blob: new Blob(['x']),
+      uploaded: false,
+    });
+    let resolveUpload: (value: { imageId: string }) => void = () => undefined;
+    imageUploaderService.uploadImageBlob.mockReturnValue(
+      new Promise<{ imageId: string }>(resolve => {
+        resolveUpload = resolve;
       }),
     );
 
-    await service.uploadImages();
+    const first = service.ensureUploaded('img-1');
+    const second = service.ensureUploaded('img-1');
 
-    expect(store.dispatch).toHaveBeenCalledWith(expect.any(AppAction.GoogleRefreshTokenInvalid));
-    expect(imageDbService.updateImage).not.toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(imageUploaderService.uploadImageBlob).toHaveBeenCalledTimes(1);
+
+    resolveUpload({ imageId: 'img-1' });
+    await expect(Promise.all([first, second])).resolves.toEqual(['uploaded', 'uploaded']);
+    expect(imageUploaderService.uploadImageBlob).toHaveBeenCalledTimes(1);
   });
 
   it('probes the files API only once when several thumbnails fail', () => {

--- a/frontend/tests/unit/services/outbound-sync.service.spec.ts
+++ b/frontend/tests/unit/services/outbound-sync.service.spec.ts
@@ -1,0 +1,176 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { EChangeAction, EChangedEntity } from '@brainassistant/contracts';
+import { of, Subject, throwError } from 'rxjs';
+import { Change } from 'src/app/shared/models/change.model';
+import { ETaskStatus, ETaskType, Task } from 'src/app/shared/models/task.model';
+import { ClientChangesService } from 'src/app/shared/services/api/client-changes.service';
+import { ImageService } from 'src/app/shared/services/application/image.service';
+import { OutboundSyncService } from 'src/app/shared/services/application/outbound-sync.service';
+
+describe('OutboundSyncService', () => {
+  let service: OutboundSyncService;
+  let clientChangesService: { send: jest.Mock };
+  let imageService: { ensureUploaded: jest.Mock; deleteImage: jest.Mock };
+
+  const pendingChange: Change = {
+    entity: EChangedEntity.Task,
+    action: EChangeAction.Created,
+    object: { id: 'task-1', modifiedAt: '2025-01-15T12:00:00.000Z' },
+  };
+
+  const taskWithPhoto: Task = {
+    id: 'task-photo',
+    userId: 'user-1',
+    type: ETaskType.Basic,
+    title: 'Photo task',
+    imageId: 'img-1',
+    status: ETaskStatus.Todo,
+    createdAt: '2025-01-15T12:00:00.000Z',
+    modifiedAt: '2025-01-15T12:00:00.000Z',
+  };
+
+  const photoCreate: Change = {
+    entity: EChangedEntity.Task,
+    action: EChangeAction.Created,
+    object: taskWithPhoto,
+  };
+
+  beforeEach(() => {
+    clientChangesService = { send: jest.fn(() => of({})) };
+    imageService = {
+      ensureUploaded: jest.fn().mockResolvedValue('alreadyRemote'),
+      deleteImage: jest.fn().mockResolvedValue(undefined),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        OutboundSyncService,
+        { provide: ClientChangesService, useValue: clientChangesService },
+        { provide: ImageService, useValue: imageService },
+      ],
+    });
+    service = TestBed.inject(OutboundSyncService);
+  });
+
+  it('sends a change that has no image to upload', async () => {
+    const result = await service.process([pendingChange]);
+
+    expect(imageService.ensureUploaded).not.toHaveBeenCalled();
+    expect(clientChangesService.send).toHaveBeenCalledWith(pendingChange);
+    expect(result).toEqual({
+      sent: [pendingChange],
+      notFound: [],
+      missingBlobDiscards: [],
+      sendFailed: false,
+    });
+  });
+
+  it('uploads a local image before sending the task change', async () => {
+    imageService.ensureUploaded.mockResolvedValue('uploaded');
+
+    const result = await service.process([photoCreate]);
+
+    expect(imageService.ensureUploaded).toHaveBeenCalledWith('img-1');
+    expect(imageService.ensureUploaded.mock.invocationCallOrder[0]).toBeLessThan(
+      clientChangesService.send.mock.invocationCallOrder[0],
+    );
+    expect(result.sent).toEqual([photoCreate]);
+  });
+
+  it('sends immediately when the image is already remote', async () => {
+    imageService.ensureUploaded.mockResolvedValue('alreadyRemote');
+
+    const result = await service.process([photoCreate]);
+
+    expect(imageService.ensureUploaded).toHaveBeenCalledWith('img-1');
+    expect(clientChangesService.send).toHaveBeenCalledWith(photoCreate);
+    expect(result.sent).toEqual([photoCreate]);
+  });
+
+  it('skips a task whose image failed to upload and still sends later unrelated changes', async () => {
+    const other: Change = {
+      entity: EChangedEntity.Task,
+      action: EChangeAction.Created,
+      object: { id: 'task-b', modifiedAt: 't' },
+    };
+    const laterUpdate: Change = {
+      entity: EChangedEntity.Task,
+      action: EChangeAction.Updated,
+      object: { ...taskWithPhoto, title: 'Updated' },
+    };
+    imageService.ensureUploaded.mockResolvedValue('failed');
+
+    const result = await service.process([photoCreate, laterUpdate, other]);
+
+    expect(clientChangesService.send).toHaveBeenCalledTimes(1);
+    expect(clientChangesService.send).toHaveBeenCalledWith(other);
+    expect(result.sent).toEqual([other]);
+    expect(result.sendFailed).toBe(false);
+  });
+
+  it('does not send a task whose image blob is missing and deletes the local file', async () => {
+    imageService.ensureUploaded.mockResolvedValue('missingBlob');
+
+    const result = await service.process([photoCreate]);
+
+    expect(clientChangesService.send).not.toHaveBeenCalled();
+    expect(imageService.deleteImage).toHaveBeenCalledWith('img-1');
+    expect(result.missingBlobDiscards).toEqual([{ taskId: 'task-photo', imageId: 'img-1' }]);
+  });
+
+  it('stops the queue on a non-404 send error', async () => {
+    const first: Change = { ...pendingChange, object: { id: 'task-a', modifiedAt: 't' } };
+    const second: Change = { ...pendingChange, object: { id: 'task-b', modifiedAt: 't' } };
+    clientChangesService.send.mockReturnValue(
+      throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Server Error' })),
+    );
+
+    const result = await service.process([first, second]);
+
+    expect(clientChangesService.send).toHaveBeenCalledTimes(1);
+    expect(result.sent).toEqual([]);
+    expect(result.sendFailed).toBe(true);
+  });
+
+  it('records a 404 send as notFound and continues', async () => {
+    const first: Change = { ...pendingChange, object: { id: 'task-a', modifiedAt: 't' } };
+    const second: Change = { ...pendingChange, object: { id: 'task-b', modifiedAt: 't' } };
+    clientChangesService.send
+      .mockReturnValueOnce(
+        throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' })),
+      )
+      .mockReturnValue(of({}));
+
+    const result = await service.process([first, second]);
+
+    expect(result.notFound).toEqual([first]);
+    expect(result.sent).toEqual([second]);
+    expect(result.sendFailed).toBe(false);
+  });
+
+  it('does not start the next send while one is in flight', async () => {
+    const first: Change = { ...pendingChange, object: { id: 'task-a', modifiedAt: 't' } };
+    const second: Change = { ...pendingChange, object: { id: 'task-b', modifiedAt: 't' } };
+    const sendGate = new Subject<unknown>();
+    clientChangesService.send.mockReturnValueOnce(sendGate.asObservable()).mockReturnValue(of({}));
+
+    const done = service.process([first, second]);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(clientChangesService.send).toHaveBeenCalledTimes(1);
+    expect(clientChangesService.send).toHaveBeenCalledWith(first);
+
+    sendGate.next({});
+    sendGate.complete();
+    await expect(done).resolves.toEqual({
+      sent: [first, second],
+      notFound: [],
+      missingBlobDiscards: [],
+      sendFailed: false,
+    });
+    expect(clientChangesService.send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/tests/unit/state/mb-task-screen.state.spec.ts
+++ b/frontend/tests/unit/state/mb-task-screen.state.spec.ts
@@ -116,6 +116,28 @@ describe('MbTaskScreenState', () => {
     expect(store.selectSnapshot(MbTaskScreenState.task)).toEqual(existingWithPhoto);
     expect(store.selectSnapshot(MbTaskScreenState.imageUri)).toBeNull();
   });
+
+  it('saves a new photo when applying an edit', async () => {
+    deviceCameraService.takePicture.mockResolvedValue('blob:edited-photo');
+
+    await firstValueFrom(
+      store.dispatch(new MbTaskScreenAction.Opened(ETaskViewMode.View, existingWithPhoto.id)),
+    );
+    await firstValueFrom(store.dispatch(MbTaskScreenAction.EditTaskOptionSelected));
+    await firstValueFrom(store.dispatch(MbTaskScreenAction.AddPictureBtnPressed));
+    await firstValueFrom(
+      store.dispatch(
+        new MbTaskScreenAction.UpdateFormData(true, { title: existingWithPhoto.title }),
+      ),
+    );
+    await firstValueFrom(store.dispatch(MbTaskScreenAction.ApplyButtonPressed));
+
+    expect(imageService.saveImage).toHaveBeenCalledWith('blob:edited-photo');
+    const updated = store
+      .selectSnapshot(TasksState.allTasks)
+      .find(t => t.id === existingWithPhoto.id);
+    expect(updated?.imageId).toBe('new-image-id');
+  });
 });
 
 function leftoverCreateState() {

--- a/frontend/tests/unit/state/sync.state.spec.ts
+++ b/frontend/tests/unit/state/sync.state.spec.ts
@@ -2,22 +2,26 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { Actions, ofActionDispatched, provideStore, Store } from '@ngxs/store';
 import { EChangeAction, EChangedEntity } from '@brainassistant/contracts';
-import { firstValueFrom, of, Subject, throwError } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
 import { Change } from 'src/app/shared/models/change.model';
-import { ClientChangesService } from 'src/app/shared/services/api/client-changes.service';
+import { ETaskStatus, ETaskType, Task } from 'src/app/shared/models/task.model';
 import { ClientIdService } from 'src/app/shared/services/api/client-id.service';
 import { ServerChangesService } from 'src/app/shared/services/api/server-changes.service';
-import { ImageService } from 'src/app/shared/services/application/image.service';
+import {
+  OutboundSyncResult,
+  OutboundSyncService,
+} from 'src/app/shared/services/application/outbound-sync.service';
+import { AppAction } from 'src/app/shared/state/app.actions';
 import { SyncAction } from 'src/app/shared/state/sync.action';
 import { SyncState, SyncStateModel } from 'src/app/shared/state/sync.state';
+import { TasksState } from 'src/app/shared/state/tasks.state';
 
 describe('SyncState', () => {
   let store: Store;
   let actions$: Actions;
   let clientIdService: { releaseClientId: jest.Mock };
   let serverChangesService: { fetch: jest.Mock };
-  let clientChangesService: { send: jest.Mock };
-  let imageService: { uploadImages: jest.Mock };
+  let outboundSyncService: { process: jest.Mock };
 
   const pendingChange: Change = {
     entity: EChangedEntity.Task,
@@ -25,19 +29,26 @@ describe('SyncState', () => {
     object: { id: 'task-1', modifiedAt: '2025-01-15T12:00:00.000Z' },
   };
 
+  const emptyResult: OutboundSyncResult = {
+    sent: [],
+    notFound: [],
+    missingBlobDiscards: [],
+    sendFailed: false,
+  };
+
   beforeEach(() => {
     clientIdService = { releaseClientId: jest.fn(() => of('client-1')) };
     serverChangesService = { fetch: jest.fn(() => of([])) };
-    clientChangesService = { send: jest.fn(() => of({})) };
-    imageService = { uploadImages: jest.fn().mockResolvedValue(undefined) };
+    outboundSyncService = {
+      process: jest.fn(async (changes: Change[]) => ({ ...emptyResult, sent: changes })),
+    };
 
     TestBed.configureTestingModule({
       providers: [
-        provideStore([SyncState]),
+        provideStore([SyncState, TasksState]),
         { provide: ClientIdService, useValue: clientIdService },
         { provide: ServerChangesService, useValue: serverChangesService },
-        { provide: ClientChangesService, useValue: clientChangesService },
-        { provide: ImageService, useValue: imageService },
+        { provide: OutboundSyncService, useValue: outboundSyncService },
       ],
     });
 
@@ -45,23 +56,18 @@ describe('SyncState', () => {
     actions$ = TestBed.inject(Actions);
   });
 
-  it('enqueues a local change and removes it after a successful send', async () => {
-    resetSync({ clientId: 'client-1', lastTime: null, changes: [pendingChange] });
+  it('enqueues a local change and removes it after outbound sync reports it sent', async () => {
+    resetState({ clientId: 'client-1', lastTime: null, changes: [pendingChange] });
 
     await firstValueFrom(store.dispatch(new SyncAction.Synchronize()));
 
-    expect(clientChangesService.send).toHaveBeenCalledWith(pendingChange);
+    expect(outboundSyncService.process).toHaveBeenCalledWith([pendingChange]);
     expect(syncSnapshot().changes).toEqual([]);
   });
 
-  it('stops the queue on a non-404 send error and keeps the pending change', async () => {
-    const first: Change = { ...pendingChange, object: { id: 'task-a', modifiedAt: 't' } };
-    const second: Change = { ...pendingChange, object: { id: 'task-b', modifiedAt: 't' } };
-    resetSync({ clientId: 'client-1', lastTime: null, changes: [first, second] });
-
-    clientChangesService.send.mockReturnValue(
-      throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Server Error' })),
-    );
+  it('keeps the queue and reports failure when outbound sync cannot send', async () => {
+    outboundSyncService.process.mockResolvedValue({ ...emptyResult, sendFailed: true });
+    resetState({ clientId: 'client-1', lastTime: null, changes: [pendingChange] });
 
     const failed: SyncAction.SyncinhriniziationWasFailed[] = [];
     const sub = actions$
@@ -71,13 +77,61 @@ describe('SyncState', () => {
     await firstValueFrom(store.dispatch(new SyncAction.Synchronize()));
     sub.unsubscribe();
 
-    expect(clientChangesService.send).toHaveBeenCalledTimes(1);
-    expect(syncSnapshot().changes).toEqual([first, second]);
+    expect(syncSnapshot().changes).toEqual([pendingChange]);
     expect(failed).toHaveLength(1);
   });
 
+  it('removes a local task when outbound sync reports a missing photo blob', async () => {
+    const taskWithPhoto: Task = {
+      id: 'task-photo',
+      userId: 'user-1',
+      type: ETaskType.Basic,
+      title: 'Photo task',
+      imageId: 'img-1',
+      status: ETaskStatus.Todo,
+      createdAt: '2025-01-15T12:00:00.000Z',
+      modifiedAt: '2025-01-15T12:00:00.000Z',
+    };
+    const photoCreate: Change = {
+      entity: EChangedEntity.Task,
+      action: EChangeAction.Created,
+      object: taskWithPhoto,
+    };
+    outboundSyncService.process.mockImplementation(async (changes: Change[]) => {
+      const hasUnsentPhotoCreate = changes.some(
+        change => change.action === EChangeAction.Created && change.object?.id === taskWithPhoto.id,
+      );
+      if (hasUnsentPhotoCreate) {
+        return {
+          ...emptyResult,
+          missingBlobDiscards: [{ taskId: taskWithPhoto.id, imageId: 'img-1' }],
+        };
+      }
+      return { ...emptyResult, sent: changes };
+    });
+    resetState({ clientId: 'client-1', lastTime: null, changes: [photoCreate] }, [taskWithPhoto]);
+
+    const errors: AppAction.ShowErrorInUI[] = [];
+    const sub = actions$
+      .pipe(ofActionDispatched(AppAction.ShowErrorInUI))
+      .subscribe(action => errors.push(action));
+
+    await firstValueFrom(store.dispatch(new SyncAction.Synchronize()));
+    sub.unsubscribe();
+
+    expect(errors).toHaveLength(1);
+    expect(
+      store.selectSnapshot((state: { tasks: { entities: Task[] } }) => state.tasks.entities),
+    ).toEqual([]);
+    expect(
+      syncSnapshot().changes.some(
+        change => change.action === EChangeAction.Created && change.object?.id === 'task-photo',
+      ),
+    ).toBe(false);
+  });
+
   it('clears clientId on fetch 404 and allocates a new one on the retry', async () => {
-    resetSync({ clientId: 'stale-client', lastTime: null, changes: [] });
+    resetState({ clientId: 'stale-client', lastTime: null, changes: [] });
 
     serverChangesService.fetch
       .mockReturnValueOnce(
@@ -100,35 +154,11 @@ describe('SyncState', () => {
     expect(serverChangesService.fetch).toHaveBeenCalledWith('client-2');
   });
 
-  it('does not drain the rest of the queue while a send is in flight', async () => {
-    const first: Change = { ...pendingChange, object: { id: 'task-a', modifiedAt: 't' } };
-    const second: Change = { ...pendingChange, object: { id: 'task-b', modifiedAt: 't' } };
-    resetSync({ clientId: 'client-1', lastTime: null, changes: [first, second] });
-
-    const sendGate = new Subject<unknown>();
-    clientChangesService.send
-      .mockReturnValueOnce(sendGate.asObservable())
-      .mockReturnValue(of({}));
-
-    const syncDone = firstValueFrom(store.dispatch(new SyncAction.Synchronize()));
-
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(clientChangesService.send).toHaveBeenCalledTimes(1);
-    expect(clientChangesService.send).toHaveBeenCalledWith(first);
-    expect(syncSnapshot().changes).toEqual([first, second]);
-
-    sendGate.next({});
-    sendGate.complete();
-    await syncDone;
-
-    expect(clientChangesService.send).toHaveBeenCalledTimes(2);
-    expect(syncSnapshot().changes).toEqual([]);
-  });
-
-  function resetSync(sync: SyncStateModel): void {
-    store.reset({ sync });
+  function resetState(sync: SyncStateModel, tasks: Task[] = []): void {
+    store.reset({
+      sync,
+      tasks: { entities: tasks },
+    });
   }
 
   function syncSnapshot(): SyncStateModel {


### PR DESCRIPTION
## Summary
- A task with a new local photo is not posted to `/api/sync/task` until `POST /api/files/image` succeeds, so other devices never see an `imageId` that 404s.
- Outbound queue processing (bytes-first upload, skip that task on upload failure, discard on missing blob) lives in `OutboundSyncService`; `SyncState.syncPendingChanges` applies the result.
- Editing a task with a new camera photo now saves a new `imageId`. Drive 403 still goes only through the HTTP interceptor.

## Test plan
- [ ] Create a task with a photo while online: Network shows image POST, then task POST, same `imageId`.
- [ ] Create a task with a photo while offline: task stays on this device; no task POST until back online and the photo uploads.
- [ ] Fail image upload (500): task remains on home, task POST does not go out, retries on the next sync tick.
- [ ] Edit an existing task and attach a new photo: new `imageId` is saved and uploaded before the PATCH.
- [ ] Second device sees the task only after the photo has been uploaded.

Made with [Cursor](https://cursor.com)